### PR TITLE
Added some update by tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,6 @@
 	<artifactId>deephaven-benchmark</artifactId>
 	<version>1.0-SNAPSHOT</version>
 	<name>deephaven-benchmark</name>
-
 	<build>
 		<plugins>
 			<plugin>
@@ -148,7 +147,6 @@
 			</extension>
 		</extensions>
 	</build>
-
 	<dependencies>
 		<!-- Added because of conflict with 4.1.68  -->
 		<dependency>
@@ -156,54 +154,39 @@
 			<artifactId>netty-all</artifactId>
 			<version>4.1.79.Final</version>
 		</dependency>
-
 		<!-- Added because of conflict with 1.41.0 -->
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-all</artifactId>
 			<version>1.50.1</version>
 		</dependency>
-
 		<!-- Added because of conflict with 3.17.3 -->
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
 			<version>3.21.9</version>
 		</dependency>
-
 		<dependency>
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-avro-serializer</artifactId>
 			<version>7.3.1</version>
 		</dependency>
-
 		<dependency>
 			<groupId>io.deephaven</groupId>
 			<artifactId>deephaven-java-client-barrage-dagger</artifactId>
 			<version>0.21.0</version>
 		</dependency>
-
 		<dependency>
 			<groupId>io.deephaven</groupId>
 			<artifactId>deephaven-log-to-slf4j</artifactId>
 			<version>0.21.0</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-console-standalone</artifactId>
 			<version>1.9.2</version>
 		</dependency>
-
-<!--
-		<dependency>
-			<groupId>com.diffplug.spotless</groupId>
-			<artifactId>spotless-maven-plugin</artifactId>
-			<version>2.33.0</version>
-		</dependency>-->
-
 	</dependencies>
-
 	<repositories>
 		<repository>
 			<id>confluent.io</id>
@@ -211,5 +194,4 @@
 			<url>https://packages.confluent.io/maven/</url>
 		</repository>
 	</repositories>
-
 </project>

--- a/src/it/java/io/deephaven/benchmark/tests/standard/by/CountByTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/by/CountByTest.java
@@ -16,12 +16,6 @@ public class CountByTest {
     }
 
     @Test
-    public void countBy0Groups3Cols() {
-        var q = "source.count_by('count')";
-        runner.test("CountBy- No Groups 250 Unique Vals", 1, q, "str250", "str640", "int250");
-    }
-
-    @Test
     public void countBy1IntGroup1Col() {
         var q = "source.count_by('count', by=['int250'])";
         runner.test("CountBy- 1 Int Group 250 Unique Vals", 250, q, "int250");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMaxTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMaxTest.java
@@ -1,0 +1,43 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Calculates a cumulative maximum for specified columns and places the
+ * result into a new column for each row.
+ */
+public class CumMaxTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.api().table("source").random()
+                .add("int5", "int", "[1-5]")
+                .add("int10", "int", "[1-10]")
+                .add("str100", "string", "s[1-100]")
+                .add("str150", "string", "[1-150]s")
+                .generateParquet();
+        runner.api().query("from deephaven.updateby import cum_max").execute();
+    }
+
+    @Test
+    public void cumMax1Group2Cols() {
+        var q = "source.update_by(ops=cum_max(cols=['X=int5']), by=['str100'])";
+        runner.test("CumMax- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
+    }
+
+    @Test
+    public void cumMax1Group3Cols() {
+        var q = "source.update_by(ops=cum_max(cols=['X=int5','CP2=int10']), by=['str100'])";
+        runner.test("CumMax- 1 Group 100 Unique Vals 3 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
+    }
+
+    @Test
+    public void cumMax2Groups3Cols() {
+        var q = "source.update_by(ops=cum_max(cols=['X=int5']), by=['str100','str150'])";
+        runner.test("CumMax- 2 Groups 160K Unique Combos 3 Cols", runner.scaleRowCount, q, "str100", "str150", "int5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMaxTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMaxTest.java
@@ -23,6 +23,18 @@ public class CumMaxTest {
     }
 
     @Test
+    public void cumMax0Group1Col() {
+        var q = "source.update_by(ops=cum_max(cols=['X=int5']))";
+        runner.test("CumMax- No Groups 1 Col", runner.scaleRowCount, q, "int5");
+    }
+
+    @Test
+    public void cumMax0Group2Cols() {
+        var q = "source.update_by(ops=cum_max(cols=['X=int5','Y=int10']))";
+        runner.test("CumMax- No Groups 2 Cols", runner.scaleRowCount, q, "int5", "int10");
+    }
+
+    @Test
     public void cumMax1Group2Cols() {
         var q = "source.update_by(ops=cum_max(cols=['X=int5']), by=['str100'])";
         runner.test("CumMax- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
@@ -30,7 +42,7 @@ public class CumMaxTest {
 
     @Test
     public void cumMax1Group3Cols() {
-        var q = "source.update_by(ops=cum_max(cols=['X=int5','CP2=int10']), by=['str100'])";
+        var q = "source.update_by(ops=cum_max(cols=['X=int5','Y=int10']), by=['str100'])";
         runner.test("CumMax- 1 Group 100 Unique Vals 3 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMinTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMinTest.java
@@ -23,6 +23,18 @@ public class CumMinTest {
     }
 
     @Test
+    public void cumMin0Group1Col() {
+        var q = "source.update_by(ops=cum_min(cols=['X=int5']))";
+        runner.test("CumMin- No Groups 1 Cols", runner.scaleRowCount, q, "int5");
+    }
+
+    @Test
+    public void cumMin0Group2Cols() {
+        var q = "source.update_by(ops=cum_min(cols=['X=int5','Y=int10']))";
+        runner.test("CumMin- No Groups 2 Cols", runner.scaleRowCount, q, "int5", "int10");
+    }
+
+    @Test
     public void cumMin1Group2Cols() {
         var q = "source.update_by(ops=cum_min(cols=['X=int5']), by=['str100'])";
         runner.test("CumMin- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMinTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMinTest.java
@@ -1,0 +1,43 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Calculates a cumulative minimum for specified columns and places the
+ * result into a new column for each row.
+ */
+public class CumMinTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.api().table("source").random()
+                .add("int5", "int", "[1-5]")
+                .add("int10", "int", "[1-10]")
+                .add("str100", "string", "s[1-100]")
+                .add("str150", "string", "[1-150]s")
+                .generateParquet();
+        runner.api().query("from deephaven.updateby import cum_min").execute();
+    }
+
+    @Test
+    public void cumMin1Group2Cols() {
+        var q = "source.update_by(ops=cum_min(cols=['X=int5']), by=['str100'])";
+        runner.test("CumMin- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
+    }
+
+    @Test
+    public void cumMin1Group3Cols() {
+        var q = "source.update_by(ops=cum_min(cols=['X=int5','Y=int10']), by=['str100'])";
+        runner.test("CumMin- 1 Group 100 Unique Vals 3 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
+    }
+
+    @Test
+    public void cumMin2Groups3Cols() {
+        var q = "source.update_by(ops=cum_min(cols=['X=int5']), by=['str100','str150'])";
+        runner.test("CumMin- 2 Groups 160K Unique Combos 3 Cols", runner.scaleRowCount, q, "str100", "str150", "int5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumProdTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumProdTest.java
@@ -1,0 +1,43 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Calculates a cumulative product for specified columns and places
+ * the result into a new column for each row.
+ */
+public class CumProdTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.api().table("source").random()
+                .add("int5", "int", "[1-5]")
+                .add("int10", "int", "[1-10]")
+                .add("str100", "string", "s[1-100]")
+                .add("str150", "string", "[1-150]s")
+                .generateParquet();
+        runner.api().query("from deephaven.updateby import cum_prod").execute();
+    }
+
+    @Test
+    public void cumProd1Group2Cols() {
+        var q = "source.update_by(ops=cum_prod(cols=['X1=int5']), by=['str100'])";
+        runner.test("CumProd- 1 Group 100 Unique Vals 2 Col", runner.scaleRowCount, q, "str100", "int5");
+    }
+
+    @Test
+    public void cumProd1Group3Cols() {
+        var q = "source.update_by(ops=cum_prod(cols=['X=int5','CP2=int10']), by=['str100'])";
+        runner.test("CumProd- 1 Group 100 Unique Vals 3 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
+    }
+
+    @Test
+    public void cumProd2Groups3Cols() {
+        var q = "source.update_by(ops=cum_prod(cols=['X=int5']), by=['str100','str150'])";
+        runner.test("CumProd- 2 Groups 160K Unique Combos 3 Cols", runner.scaleRowCount, q, "str100", "str150", "int5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumProdTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumProdTest.java
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.*;
 import io.deephaven.benchmark.tests.standard.StandardTestRunner;
 
 /**
- * Standard tests for the updateBy table operation. Calculates a cumulative product for specified columns and places
- * the result into a new column for each row.
+ * Standard tests for the updateBy table operation. Calculates a cumulative product for specified columns and places the
+ * result into a new column for each row.
  */
 public class CumProdTest {
     final StandardTestRunner runner = new StandardTestRunner(this);
@@ -23,6 +23,18 @@ public class CumProdTest {
     }
 
     @Test
+    public void cumProd0Group1Col() {
+        var q = "source.update_by(ops=cum_prod(cols=['X1=int5']))";
+        runner.test("CumProd- No Groups 1 Col", runner.scaleRowCount, q, "int5");
+    }
+
+    @Test
+    public void cumProd0Group2Cols() {
+        var q = "source.update_by(ops=cum_prod(cols=['X=int5','Y=int10']))";
+        runner.test("CumProd- No Groups 2 Cols", runner.scaleRowCount, q, "int5", "int10");
+    }
+
+    @Test
     public void cumProd1Group2Cols() {
         var q = "source.update_by(ops=cum_prod(cols=['X1=int5']), by=['str100'])";
         runner.test("CumProd- 1 Group 100 Unique Vals 2 Col", runner.scaleRowCount, q, "str100", "int5");
@@ -30,7 +42,7 @@ public class CumProdTest {
 
     @Test
     public void cumProd1Group3Cols() {
-        var q = "source.update_by(ops=cum_prod(cols=['X=int5','CP2=int10']), by=['str100'])";
+        var q = "source.update_by(ops=cum_prod(cols=['X=int5','Y=int10']), by=['str100'])";
         runner.test("CumProd- 1 Group 100 Unique Vals 3 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumSumTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumSumTest.java
@@ -23,14 +23,26 @@ public class CumSumTest {
     }
 
     @Test
+    public void cumSum0Group1Col() {
+        var q = "source.update_by(ops=cum_sum(cols=['X=int5']))";
+        runner.test("CumSum- No Groups 1 Col", runner.scaleRowCount, q, "int5");
+    }
+
+    @Test
+    public void cumSum0Group2Cols() {
+        var q = "source.update_by(ops=cum_sum(cols=['X=int5','Y=int10']))";
+        runner.test("CumSum- No Groups 2 Cols", runner.scaleRowCount, q, "int5", "int10");
+    }
+
+    @Test
     public void cumSum1Group2Cols() {
         var q = "source.update_by(ops=cum_sum(cols=['X=int5']), by=['str100'])";
-        runner.test("CumSum- 1 Group 100 Unique Vals 1 Col", runner.scaleRowCount, q, "str100", "int5");
+        runner.test("CumSum- 1 Group 100 Unique Vals 2 Col", runner.scaleRowCount, q, "str100", "int5");
     }
 
     @Test
     public void cumSum1Group3Cols() {
-        var q = "source.update_by(ops=cum_sum(cols=['X=int5','CP2=int10']), by=['str100'])";
+        var q = "source.update_by(ops=cum_sum(cols=['X=int5','Y=int10']), by=['str100'])";
         runner.test("CumSum- 1 Group 100 Unique Vals 3 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumSumTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumSumTest.java
@@ -1,0 +1,43 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Calculates a cumulative sum for specified columns and places the
+ * result into a new column for each row.
+ */
+public class CumSumTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.api().table("source").random()
+                .add("int5", "int", "[1-5]")
+                .add("int10", "int", "[1-10]")
+                .add("str100", "string", "s[1-100]")
+                .add("str150", "string", "[1-150]s")
+                .generateParquet();
+        runner.api().query("from deephaven.updateby import cum_sum").execute();
+    }
+
+    @Test
+    public void cumSum1Group2Cols() {
+        var q = "source.update_by(ops=cum_sum(cols=['X=int5']), by=['str100'])";
+        runner.test("CumSum- 1 Group 100 Unique Vals 1 Col", runner.scaleRowCount, q, "str100", "int5");
+    }
+
+    @Test
+    public void cumSum1Group3Cols() {
+        var q = "source.update_by(ops=cum_sum(cols=['X=int5','CP2=int10']), by=['str100'])";
+        runner.test("CumSum- 1 Group 100 Unique Vals 3 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
+    }
+
+    @Test
+    public void cumSum2Groups3Cols() {
+        var q = "source.update_by(ops=cum_sum(cols=['X=int5']), by=['str100','str150'])";
+        runner.test("CumSum- 2 Groups 160K Unique Combos 3 Cols", runner.scaleRowCount, q, "str100", "str150", "int5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTickDecayTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTickDecayTest.java
@@ -23,6 +23,18 @@ public class EmaTickDecayTest {
     }
 
     @Test
+    public void emaTickDecay0Group1Col() {
+        var q = "source.update_by(ops=ema_tick_decay(time_scale_ticks=100,cols=['X=int5']))";
+        runner.test("EmaTickDecay- No Groups 1 Col", runner.scaleRowCount, q, "int5");
+    }
+
+    @Test
+    public void emaTickDecay0Group2Cols() {
+        var q = "source.update_by(ops=ema_tick_decay(time_scale_ticks=100,cols=['X=int5','Y=int10']))";
+        runner.test("EmaTickDecay- No Groups 2 Cols", runner.scaleRowCount, q, "int5", "int10");
+    }
+
+    @Test
     public void emaTickDecay1Group2Cols() {
         var q = "source.update_by(ops=ema_tick_decay(time_scale_ticks=100,cols=['X=int5']), by=['str100'])";
         runner.test("EmaTickDecay- 1 Group 100 Unique Vals 2 Col", runner.scaleRowCount, q, "str100", "int5");
@@ -37,7 +49,8 @@ public class EmaTickDecayTest {
     @Test
     public void emaTickDecay2Groups3Cols() {
         var q = "source.update_by(ops=ema_tick_decay(time_scale_ticks=100,cols=['X=int5']), by=['str100','str150'])";
-        runner.test("EmaTickDecay- 2 Groups 160K Unique Combos 3 Cols", runner.scaleRowCount, q, "str100", "str150", "int5");
+        runner.test("EmaTickDecay- 2 Groups 160K Unique Combos 3 Cols", runner.scaleRowCount, q, "str100", "str150",
+                "int5");
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTickDecayTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTickDecayTest.java
@@ -1,0 +1,43 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Calculates a tick-based exponential moving average for specified
+ * columns and places the result into a new column for each row.
+ */
+public class EmaTickDecayTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.api().table("source").random()
+                .add("int5", "int", "[1-5]")
+                .add("int10", "int", "[1-10]")
+                .add("str100", "string", "s[1-100]")
+                .add("str150", "string", "[1-150]s")
+                .generateParquet();
+        runner.api().query("from deephaven.updateby import ema_tick_decay").execute();
+    }
+
+    @Test
+    public void emaTickDecay1Group2Cols() {
+        var q = "source.update_by(ops=ema_tick_decay(time_scale_ticks=100,cols=['X=int5']), by=['str100'])";
+        runner.test("EmaTickDecay- 1 Group 100 Unique Vals 2 Col", runner.scaleRowCount, q, "str100", "int5");
+    }
+
+    @Test
+    public void emaTickDecay1Group3Cols() {
+        var q = "source.update_by(ops=ema_tick_decay(time_scale_ticks=100,cols=['X=int5','Y=int10']), by=['str100'])";
+        runner.test("EmaTickDecay- 1 Group 100 Unique Vals 3 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
+    }
+
+    @Test
+    public void emaTickDecay2Groups3Cols() {
+        var q = "source.update_by(ops=ema_tick_decay(time_scale_ticks=100,cols=['X=int5']), by=['str100','str150'])";
+        runner.test("EmaTickDecay- 2 Groups 160K Unique Combos 3 Cols", runner.scaleRowCount, q, "str100", "str150", "int5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTimeDecayTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTimeDecayTest.java
@@ -1,0 +1,40 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Calculates a tick-based exponential moving average for specified
+ * columns and places the result into a new column for each row.
+ */
+public class EmaTimeDecayTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+    final long rowCount = runner.scaleRowCount;
+
+    @BeforeEach
+    public void setup() {
+        long baseTime = 1676557157537L;
+        runner.api().table("source").fixed()
+                .add("timestamp", "timestamp-millis", "[" + baseTime + "-" + (baseTime + rowCount - 1) + "]")
+                .add("intScale", "int", "[1-" + (rowCount - 1) + "]")
+                .add("str100", "string", "s[1-100]")
+                .add("str150", "string", "[1-150]s")
+                .generateParquet();
+        runner.api().query("from deephaven.updateby import ema_time_decay").execute();
+    }
+
+    @Test
+    public void emaTimeDecay1Group3Cols() {
+        var q = "source.update_by(ops=ema_time_decay(ts_col='timestamp', time_scale='00:00:02', cols=['X=intScale']), by=['str100'])";
+        runner.test("EmaTimeDecay- 1 Group 100 Unique Vals 2 Col", rowCount, q, "str100", "intScale", "timestamp");
+    }
+
+    @Test
+    public void emaTimeDecay2Groups4Cols() {
+        var q = "source.update_by(ops=ema_time_decay(ts_col='timestamp', time_scale='00:00:02', cols=['X=intScale']), by=['str100','str150'])";
+        runner.test("EmaTickDecay- 2 Groups 160K Unique Combos 3 Cols", runner.scaleRowCount, q, "str100", "str150",
+                "intScale", "timestamp");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTimeDecayTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTimeDecayTest.java
@@ -25,6 +25,12 @@ public class EmaTimeDecayTest {
     }
 
     @Test
+    public void emaTimeDecay0Group2Cols() {
+        var q = "source.update_by(ops=ema_time_decay(ts_col='timestamp', time_scale='00:00:02', cols=['X=intScale']))";
+        runner.test("EmaTimeDecay- No Groups 1 Col", rowCount, q, "intScale", "timestamp");
+    }
+
+    @Test
     public void emaTimeDecay1Group3Cols() {
         var q = "source.update_by(ops=ema_time_decay(ts_col='timestamp', time_scale='00:00:02', cols=['X=intScale']), by=['str100'])";
         runner.test("EmaTimeDecay- 1 Group 100 Unique Vals 2 Col", rowCount, q, "str100", "intScale", "timestamp");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTickTest.java
@@ -28,6 +28,12 @@ public class RollingSumTickTest {
     }
 
     @Test
+    public void rollingSumTick0Group1Col() {
+        var q = "source.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingSumTick- No Groups 1 Cols", runner.scaleRowCount, q, "intScale");
+    }
+
+    @Test
     public void rollingSumTick1Group2Cols() {
         var q = "source.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
         runner.test("RollingSumTick- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "intScale");
@@ -36,7 +42,8 @@ public class RollingSumTickTest {
     @Test
     public void rollingSumTick2Groups3Cols() {
         var q = "source.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("CumSum- 2 Groups 160K Unique Combos 3 Cols", runner.scaleRowCount, q, "str100", "str150", "intScale");
+        runner.test("CumSum- 2 Groups 160K Unique Combos 3 Cols", runner.scaleRowCount, q, "str100", "str150",
+                "intScale");
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTickTest.java
@@ -1,0 +1,42 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a tick-based rolling sum. The result table contains
+ * additional columns with windowed rolling sums for each specified column in the source table.
+ */
+public class RollingSumTickTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.api().table("source").fixed()
+                .add("intScale", "int", "[1-" + runner.scaleRowCount + "]")
+                .add("str100", "string", "s[1-100]")
+                .add("str150", "string", "[1-150]s")
+                .generateParquet();
+        var setup = """
+        from deephaven.updateby import rolling_sum_tick
+        contains_row = rolling_sum_tick(cols=["Contains = intScale"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_sum_tick(cols=["Before = intScale"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_sum_tick(cols=["After = intScale"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.api().query(setup).execute();
+    }
+
+    @Test
+    public void rollingSumTick1Group2Cols() {
+        var q = "source.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingSumTick- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "intScale");
+    }
+
+    @Test
+    public void rollingSumTick2Groups3Cols() {
+        var q = "source.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("CumSum- 2 Groups 160K Unique Combos 3 Cols", runner.scaleRowCount, q, "str100", "str150", "intScale");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTimeTest.java
@@ -1,0 +1,47 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a time-based rolling sum. The result table contains
+ * additional columns with windowed rolling sums for each specified column in the source table.
+ */
+public class RollingSumTimeTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+    final long rowCount = runner.scaleRowCount;
+
+    @BeforeEach
+    public void setup() {
+        long baseTime = 1676557157537L;
+        runner.api().table("source").fixed()
+                .add("timestamp", "timestamp-millis", "[" + baseTime + "-" + (baseTime + rowCount - 1) + "]")
+                .add("intScale", "int", "[1-" + (rowCount - 1) + "]")
+                .add("str100", "string", "s[1-100]")
+                .add("str150", "string", "[1-150]s")
+                .generateParquet();
+        var setup = """
+        from deephaven.updateby import rolling_sum_time
+        contains_row = rolling_sum_time(ts_col="timestamp", cols=["X=intScale"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_sum_time(ts_col="timestamp", cols=["Y=intScale"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_sum_time(ts_col="timestamp", cols=["Z=intScale"], rev_time="-00:00:01", fwd_time=int(3e9))
+        
+        """;
+        runner.api().query(setup).execute();
+    }
+
+    @Test
+    public void rollingSumTime1Group3Cols() {
+        var q = "source.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingSumTime- 1 Group 100 Unique Vals 3 Cols", rowCount, q, "str100", "intScale", "timestamp");
+    }
+
+    @Test
+    public void rollingSumTime2Groups4Cols() {
+        var q = "source.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingSumTime- 2 Groups 160K Unique Combos 4 Cols", rowCount, q, "str100", "str150",
+                "intScale", "timestamp");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTimeTest.java
@@ -32,6 +32,12 @@ public class RollingSumTimeTest {
     }
 
     @Test
+    public void rollingSumTime0Group2Cols() {
+        var q = "source.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingSumTime- No Groups 2 Cols", rowCount, q, "intScale", "timestamp");
+    }
+
+    @Test
     public void rollingSumTime1Group3Cols() {
         var q = "source.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
         runner.test("RollingSumTime- 1 Group 100 Unique Vals 3 Cols", rowCount, q, "str100", "intScale", "timestamp");

--- a/src/main/java/io/deephaven/benchmark/connect/ColumnDefs.java
+++ b/src/main/java/io/deephaven/benchmark/connect/ColumnDefs.java
@@ -2,52 +2,117 @@
 package io.deephaven.benchmark.connect;
 
 import java.util.*;
-import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 
+/**
+ * Contains column definitions used to generate data and schemas. Columns are described by name, type, and data range
+ * (ex. "[1-100]", "str[1-100]ing"). Values are retrieved during data generation either randomly or incrementally
+ * through the range. The same seed is used for random each time this class is instantiated.
+ * <p/>
+ * Note: All possible data values are loaded up front to prevent object-creation during production. This can take a
+ * considerable amount of memory for larger scales, especially for generated strings.
+ */
 public class ColumnDefs {
     final Random random = new Random(20221130);
     final List<ColumnDef> columns = new ArrayList<>();
     private boolean isFixed = false;
 
+    /**
+     * Get the number of column definitions.
+     * 
+     * @return the number of column definitions
+     */
     public int getCount() {
         return columns.size();
     }
 
+    /**
+     * Get whether or not column values are selected incrementally through the range or random
+     * 
+     * @return true if incremental/fixed, otherwise false.
+     */
     public boolean isFixed() {
         return isFixed;
     }
 
+    /**
+     * Get the maximum possible number of values represented by the ranges in all column definitions. For example, given
+     * two column ranges [1-10] and [10-30], the count would be 20. Put another way, it's the largest range for all
+     * column definitions in this set.
+     * 
+     * @return the maximum number of values defined in this set
+     */
     public int getMaxValueCount() {
         return columns.stream().mapToInt(c -> c.maker.values.size()).max().getAsInt();
     }
 
+    /**
+     * Get a comma-separated list of quoted column names in this set
+     * 
+     * @return quoted column names.
+     */
     public String getQuotedColumns() {
-        return columns.stream().map(c -> "\"" + c.name + "\"").toList().toString().replaceAll("[\\[\\]]", "");
+        return String.join(",", columns.stream().map(c -> "\"" + c.name + "\"").toList());
     }
 
+    /**
+     * Get a map containing the name and type for each column in this definition set
+     * 
+     * @return column names and types as a map.
+     */
     public Map<String, String> toTypeMap() {
         var typeMap = new LinkedHashMap<String, String>();
         columns.stream().forEach(f -> typeMap.put(f.name(), f.type()));
         return typeMap;
     }
 
+    /**
+     * Set all column definitions to generate data incrementally.
+     */
     public void setFixed() {
         isFixed = true;
     }
 
+    /**
+     * Set all column definitions to generate data randomly.
+     */
     public void setRandom() {
         isFixed = false;
     }
 
+    /**
+     * Add a new column definition.
+     * 
+     * @param name the column name
+     * @param type the column type
+     * @param valueDef the range data (ex. "[1-10]", "str[1-100]ing")
+     * @return this
+     */
     public ColumnDefs add(String name, String type, String valueDef) {
         columns.add(new ColumnDef(name, type, valueDef, getMaker(type, valueDef)));
         return this;
     }
 
+    /**
+     * Get the next value for the column in the given index. This supports incremental and random retrieval of the
+     * column next column value according to <code>isFixed</code>
+     * 
+     * @param columnIndex the index of the column
+     * @param seed a value to use to get the next value (typically row id)
+     * @return the next value according to the column definition
+     */
     public Object nextValue(int columnIndex, long seed) {
         return columns.get(columnIndex).maker().next(seed);
     }
 
+    /**
+     * Get the column definitions as a string. It intentionall avoids OS-specific line endings.
+     * <p/>
+     * Note: This method is used to write table definitions for comparison to the file system. Do not change without
+     * understanding the impact.
+     * 
+     * @return a
+     */
     public String describe() {
         String str = "name,type,values\n";
         for (ColumnDef c : columns) {
@@ -69,6 +134,8 @@ public class ColumnDefs {
                 return new DoubleMaker(values);
             case "float":
                 return new FloatMaker(values);
+            case "timestamp-millis":
+                return new TimestampMaker(values);
             default:
                 throw new RuntimeException("Invalid field type: " + type);
         }
@@ -83,10 +150,10 @@ public class ColumnDefs {
         String[] range = brackets.replaceAll(".*\\[([0-9]+)[-]([0-9]+)\\].*", "$1,$2").split(",");
         if (range.length != 2)
             return List.of(valueDef);
-        int rangeStart = Integer.parseInt(range[0]);
-        int rangeEnd = Integer.parseInt(range[1]) + 1; // End is inclusive
+        long rangeStart = Long.parseLong(range[0]);
+        long rangeEnd = Long.parseLong(range[1]) + 1; // End is inclusive
 
-        return IntStream.range(rangeStart, rangeEnd).mapToObj(v -> valueDef.replace(brackets, Integer.toString(v)))
+        return LongStream.range(rangeStart, rangeEnd).mapToObj(v -> valueDef.replace(brackets, Long.toString(v)))
                 .toList();
     }
 
@@ -120,6 +187,12 @@ public class ColumnDefs {
     class FloatMaker extends Maker {
         FloatMaker(List<String> values) {
             super(values.stream().map(v -> (Object) Float.valueOf(v)).toList());
+        }
+    }
+
+    class TimestampMaker extends Maker {
+        TimestampMaker(List<String> values) {
+            super(values.stream().map(v -> (Object) Long.valueOf(v)).toList());
         }
     }
 

--- a/src/test/java/io/deephaven/benchmark/connect/ColumnDefsTest.java
+++ b/src/test/java/io/deephaven/benchmark/connect/ColumnDefsTest.java
@@ -40,7 +40,7 @@ public class ColumnDefsTest {
                 .add("price", "float", "[100-105]")
                 .add("priceAgain", "int", "[100-105]");
 
-        assertEquals("\"symbol\", \"price\", \"priceAgain\"", columnDefs.getQuotedColumns(), "Wrong field next");
+        assertEquals("\"symbol\",\"price\",\"priceAgain\"", columnDefs.getQuotedColumns(), "Wrong field next");
     }
 
     @Test


### PR DESCRIPTION
Besides some small changes to do timestamp types through Kafka, there are now updateBy tests for the following:

src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMaxTest.java
src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMinTest.java
src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumProdTest.java
src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumSumTest.java
src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTickDecayTest.java
src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTimeDecayTest.java
src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTickTest.java
src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTimeTest.java

Forward fill is not there yet, because the generator doesn't yet support nulls.