### PR TITLE
Generator timestamp propagation fix #58

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/internal/generator/DataTypesTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/generator/DataTypesTest.java
@@ -4,6 +4,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.*;
 import io.deephaven.benchmark.api.Bench;
 
+/**
+ * Test to ensure that data types defined for the generator are propagated through Kafka to parquet and read according
+ * to the correct corresponding Deephaven data types.
+ */
 public class DataTypesTest {
     final Bench api = Bench.create(this);
 

--- a/src/it/java/io/deephaven/benchmark/tests/internal/generator/DataTypesTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/generator/DataTypesTest.java
@@ -1,0 +1,46 @@
+package io.deephaven.benchmark.tests.internal.generator;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.api.Bench;
+
+public class DataTypesTest {
+    final Bench api = Bench.create(this);
+
+    @Test
+    public void avroDataTypes() {
+        api.table("datatypes").fixed()
+                .add("col_timestamp_millis", "timestamp-millis", "[1676557157537-1676557157537]")
+                .add("col_long", "long", "1")
+                .add("col_int", "int", "2")
+                .add("col_double", "double", "3")
+                .add("col_float", "float", "4")
+                .add("col_string", "string", "5")
+                .generateParquet();
+
+        var query = """
+        from deephaven.parquet import read
+
+        datatypes = read("/data/datatypes.parquet")
+        meta = datatypes.meta_table
+        """;
+
+        var tm = api.timer();
+        api.query(query).fetchAfter("meta", table -> {
+            assertEquals("io.deephaven.time.DateTime", table.getValue(0, "DataType").toString(), "Wrong data type");
+            assertEquals("long", table.getValue(1, "DataType").toString(), "Wrong data type");
+            assertEquals("int", table.getValue(2, "DataType").toString(), "Wrong data type");
+            assertEquals("double", table.getValue(3, "DataType").toString(), "Wrong data type");
+            assertEquals("float", table.getValue(4, "DataType").toString(), "Wrong data type");
+            assertEquals("java.lang.String", table.getValue(5, "DataType").toString(), "Wrong data type");
+        }).execute();
+        api.awaitCompletion();
+        api.result().test(tm, 1);
+    }
+
+    @AfterEach
+    public void teardown() {
+        api.close();
+    }
+
+}

--- a/src/main/java/io/deephaven/benchmark/producer/AvroKafkaGenerator.java
+++ b/src/main/java/io/deephaven/benchmark/producer/AvroKafkaGenerator.java
@@ -194,17 +194,19 @@ public class AvroKafkaGenerator implements Generator {
         for (Map.Entry<String, String> e : fieldDefs.toTypeMap().entrySet()) {
             var name = e.getKey();
             var type = e.getValue();
-            
-            if(type.equals("timestamp-millis")) type = getSchemaType("long", type);
-            else type = "'" + type + "'";
-            
+
+            if (type.equals("timestamp-millis"))
+                type = getSchemaType("long", type);
+            else
+                type = "'" + type + "'";
+
             schema += String.format(fieldFmt, name, type);
         }
 
         schema = schema.replaceAll(",\n$", "\n") + "  ]\n}\n";
         return schema.replace("'", "\"");
     }
-    
+
     private String getSchemaType(String type, String logicalType) {
         var typeFmt = "['null', { 'type' : '%s', 'logicalType' : '%s' }]";
         return String.format(typeFmt, type, logicalType);

--- a/src/main/java/io/deephaven/benchmark/producer/AvroKafkaGenerator.java
+++ b/src/main/java/io/deephaven/benchmark/producer/AvroKafkaGenerator.java
@@ -189,17 +189,25 @@ public class AvroKafkaGenerator implements Generator {
                 "  'namespace' : 'io.deephaven.benchmark',\n" +
                 "  'name' : '" + topic + "',\n" +
                 "  'fields' : [\n";
-        var fieldFmt = "    { 'name' : '%s', 'type' : '%s', 'logicalType' : '%s' },\n";
+        var fieldFmt = "    { 'name' : '%s', 'type' : %s },\n";
 
         for (Map.Entry<String, String> e : fieldDefs.toTypeMap().entrySet()) {
             var name = e.getKey();
-            var logicalType = e.getValue();
-            var type = (logicalType.equals("timestamp-millis")) ? "long" : logicalType;
-            schema += String.format(fieldFmt, name, type, logicalType);
+            var type = e.getValue();
+            
+            if(type.equals("timestamp-millis")) type = getSchemaType("long", type);
+            else type = "'" + type + "'";
+            
+            schema += String.format(fieldFmt, name, type);
         }
 
         schema = schema.replaceAll(",\n$", "\n") + "  ]\n}\n";
         return schema.replace("'", "\"");
+    }
+    
+    private String getSchemaType(String type, String logicalType) {
+        var typeFmt = "['null', { 'type' : '%s', 'logicalType' : '%s' }]";
+        return String.format(typeFmt, type, logicalType);
     }
 
 }


### PR DESCRIPTION
Fixed Avro schema for defining timestamp.  There was not error with the previous format, but a warning was getting buried.  Added an integration test to make sure that all data types were propagated properly through kafka to parquet.