### PR TITLE
Rolling avg max min prod group and combo tests

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/experimental/trades/generated/WhereTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/experimental/trades/generated/WhereTest.java
@@ -19,7 +19,7 @@ public class WhereTest {
     @Test
     public void where3Clauses() {
         var q = "quotes_g.where(filters=['(Ask - Bid) > 1', 'BidSize <= 100', 'AskSize <= 100'])";
-        runner.test("Where- 3 Clauses", 2000, q, "Sym", "Timestamp", "Bid", "BidSize", "Ask", "AskSize");
+        runner.test("Where- 3 Clauses", 20000, q, "Sym", "Timestamp", "Bid", "BidSize", "Ask", "AskSize");
     }
 
     @Test

--- a/src/it/java/io/deephaven/benchmark/tests/standard/sort/SortTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/sort/SortTest.java
@@ -24,15 +24,15 @@ public class SortTest {
     }
 
     @Test
-    public void sort2Cols() {
+    public void sort2ColsDefaultOrder() {
         var q = "source.sort(order_by=['str250', 'str640'])";
-        runner.test("Sort- 2 Cols", runner.scaleRowCount, q, "str250", "str640", "int250");
+        runner.test("Sort- 2 Cols Default Order", runner.scaleRowCount, q, "str250", "str640", "int250");
     }
 
     @Test
     public void sort2ColsOppositeOrder() {
         var q = "source.sort(order_by=['str250', 'str640'], order=[SortDirection.ASCENDING, SortDirection.DESCENDING])";
-        runner.test("Sort- 2 Cols", runner.scaleRowCount, q, "str250", "str640", "int250");
+        runner.test("Sort- 2 Cols Opposite Order", runner.scaleRowCount, q, "str250", "str640", "int250");
     }
 
     @Test

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumComboTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumComboTest.java
@@ -1,0 +1,63 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Combines multiple rolling operations
+ */
+public class CumComboTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+    final long rowCount = runner.scaleRowCount;
+    String setupStr = null;
+
+    @BeforeEach
+    public void setup() {
+        runner.tables("timed");
+        
+        setupStr = """
+        from deephaven.updateby import ema_tick_decay, ema_time_decay
+        from deephaven.updateby import cum_max, cum_min, cum_sum, cum_prod
+        
+        ema_tick_op = ema_tick_decay(time_scale_ticks=100,cols=['U=${calc.col}'])
+        ema_time_op = ema_time_decay(ts_col='timestamp', time_scale='00:00:02', cols=['V=${calc.col}'])
+        max_op = cum_max(cols=['W=${calc.col}'])
+        min_op = cum_min(cols=['X=${calc.col}'])
+        sum_op = cum_sum(cols=['Y=${calc.col}'])
+        prod_op = cum_prod(cols=['Z=${calc.col}'])
+        """;
+    }
+
+    @Test
+    public void cumComboNoGroups6Ops() {
+        runner.addSetupQuery(operations("int5"));
+        var q = "timed.update_by(ops=[ema_tick_op, ema_time_op, max_op, min_op, sum_op, prod_op])";
+        runner.test("CumCombo- 6 Ops No Groups", runner.scaleRowCount, q, "int5", "timestamp");
+    }
+
+    @Test
+    public void cumCombo2Groups6OpsInt() {
+        runner.addSetupQuery(operations("int5"));
+        var q = """
+        timed.update_by(ops=[ema_tick_op, ema_time_op, max_op, min_op, sum_op, prod_op], by=['str100','str150'])
+        """;
+        runner.test("CumCombo- 6 Ops 2 Groups 15K Unique Combos Int", rowCount, q, "str100", "str150",
+                "int5", "timestamp");
+    }
+    
+    @Test
+    public void cumCombo2Groups6OpsFloat() {
+        runner.addSetupQuery(operations("float5"));
+        var q = """
+        timed.update_by(ops=[ema_tick_op, ema_time_op, max_op, min_op, sum_op, prod_op], by=['str100','str150'])
+        """;
+        runner.test("CumCombo- 6 Ops 2 Groups 15K Unique Combos Float", rowCount, q, "str100", "str150",
+                "float5", "timestamp");
+    }
+    
+    private String operations(String type) {
+        return setupStr.replace("${calc.col}", type);
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMaxTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMaxTest.java
@@ -30,27 +30,27 @@ public class CumMaxTest {
     }
 
     @Test
-    public void cumMax1Group2Cols() {
+    public void cumMax1Group1Col() {
         var q = "timed.update_by(ops=cum_max(cols=['X=int5']), by=['str100'])";
-        runner.test("CumMax- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
+        runner.test("CumMax- 1 Group 100 Unique Vals 1 Col", runner.scaleRowCount, q, "str100", "int5");
     }
 
     @Test
-    public void cumMax1Group3Cols() {
+    public void cumMax1Group2Cols() {
         var q = "timed.update_by(ops=cum_max(cols=['X=int5','Y=int10']), by=['str100'])";
-        runner.test("CumMax- 1 Group 100 Unique Vals 3 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
+        runner.test("CumMax- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
     }
 
     @Test
     public void cumMax2GroupsInt() {
         var q = "timed.update_by(ops=cum_max(cols=['X=int5']), by=['str100','str150'])";
-        runner.test("CumMax- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150", "int5");
+        runner.test("CumMax- 2 Groups 15K Unique Combos 1 Col Int", runner.scaleRowCount, q, "str100", "str150", "int5");
     }
     
     @Test
     public void cumMax2GroupsFloat() {
         var q = "timed.update_by(ops=cum_max(cols=['X=float5']), by=['str100','str150'])";
-        runner.test("CumMax- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150", "float5");
+        runner.test("CumMax- 2 Groups 15K Unique Combos 1 Col Float", runner.scaleRowCount, q, "str100", "str150", "float5");
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMinTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMinTest.java
@@ -30,27 +30,28 @@ public class CumMinTest {
     }
 
     @Test
-    public void cumMin1Group2Cols() {
+    public void cumMin1Group1Cols() {
         var q = "timed.update_by(ops=cum_min(cols=['X=int5']), by=['str100'])";
-        runner.test("CumMin- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
+        runner.test("CumMin- 1 Group 100 Unique Vals 1 Col", runner.scaleRowCount, q, "str100", "int5");
     }
 
     @Test
-    public void cumMin1Group3Cols() {
+    public void cumMin1Group2Cols() {
         var q = "timed.update_by(ops=cum_min(cols=['X=int5','Y=int10']), by=['str100'])";
-        runner.test("CumMin- 1 Group 100 Unique Vals 3 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
+        runner.test("CumMin- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
     }
 
     @Test
     public void cumMin2GroupsInt() {
         var q = "timed.update_by(ops=cum_min(cols=['X=int5']), by=['str100','str150'])";
-        runner.test("CumMin- 2 Groups 160K Unique Combos 3 Cols", runner.scaleRowCount, q, "str100", "str150", "int5");
+        runner.test("CumMin- 2 Groups 15K Unique Combos 1 Col Int", runner.scaleRowCount, q, "str100", "str150",
+                "int5");
     }
-    
+
     @Test
     public void cumMin2GroupsFloat() {
         var q = "timed.update_by(ops=cum_min(cols=['X=float5']), by=['str100','str150'])";
-        runner.test("CumMin- 2 Groups 160K Unique Combos 3 Cols", runner.scaleRowCount, q, "str100", "str150", "float5");
+        runner.test("CumMin- 2 Groups 15K Unique Combos 1 Col Float", runner.scaleRowCount, q, "str100", "str150", "float5");
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumProdTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumProdTest.java
@@ -30,27 +30,27 @@ public class CumProdTest {
     }
 
     @Test
-    public void cumProd1Group2Cols() {
+    public void cumProd1Group1Cols() {
         var q = "timed.update_by(ops=cum_prod(cols=['X1=int5']), by=['str100'])";
-        runner.test("CumProd- 1 Group 100 Unique Vals 2 Col", runner.scaleRowCount, q, "str100", "int5");
+        runner.test("CumProd- 1 Group 100 Unique Vals 1 Col", runner.scaleRowCount, q, "str100", "int5");
     }
 
     @Test
-    public void cumProd1Group3Cols() {
+    public void cumProd1Group2Cols() {
         var q = "timed.update_by(ops=cum_prod(cols=['X=int5','Y=int10']), by=['str100'])";
-        runner.test("CumProd- 1 Group 100 Unique Vals 3 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
+        runner.test("CumProd- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
     }
 
     @Test
-    public void cumProd2GroupsInts() {
+    public void cumProd2GroupsInt() {
         var q = "timed.update_by(ops=cum_prod(cols=['X=int5']), by=['str100','str150'])";
-        runner.test("CumProd- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150", "int5");
+        runner.test("CumProd- 2 Groups 15K Unique Combos 1 Col Int", runner.scaleRowCount, q, "str100", "str150", "int5");
     }
     
     @Test
     public void cumProd2GroupsFloat() {
         var q = "timed.update_by(ops=cum_prod(cols=['X=float5']), by=['str100','str150'])";
-        runner.test("CumProd- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150", "float5");
+        runner.test("CumProd- 2 Groups 15K Unique Combos 1 Col Float", runner.scaleRowCount, q, "str100", "str150", "float5");
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumSumTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumSumTest.java
@@ -30,27 +30,27 @@ public class CumSumTest {
     }
 
     @Test
-    public void cumSum1Group2Cols() {
+    public void cumSum1Group1Col() {
         var q = "timed.update_by(ops=cum_sum(cols=['X=int5']), by=['str100'])";
-        runner.test("CumSum- 1 Group 100 Unique Vals 2 Col", runner.scaleRowCount, q, "str100", "int5");
+        runner.test("CumSum- 1 Group 100 Unique Vals 1 Cols", runner.scaleRowCount, q, "str100", "int5");
     }
 
     @Test
-    public void cumSum1Group3Cols() {
+    public void cumSum1Group2Cols() {
         var q = "timed.update_by(ops=cum_sum(cols=['X=int5','Y=int10']), by=['str100'])";
-        runner.test("CumSum- 1 Group 100 Unique Vals 3 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
+        runner.test("CumSum- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
     }
 
     @Test
     public void cumSum2GroupsInt() {
         var q = "timed.update_by(ops=cum_sum(cols=['X=int5']), by=['str100','str150'])";
-        runner.test("CumSum- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150", "int5");
+        runner.test("CumSum- 2 Groups 15K Unique Combos 1 Col Int", runner.scaleRowCount, q, "str100", "str150", "int5");
     }
     
     @Test
     public void cumSum2GroupsFloat() {
         var q = "timed.update_by(ops=cum_sum(cols=['X=float5']), by=['str100','str150'])";
-        runner.test("CumSum- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150", "float5");
+        runner.test("CumSum- 2 Groups 15K Unique Combos 1 Col Float", runner.scaleRowCount, q, "str100", "str150", "float5");
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTickDecayTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTickDecayTest.java
@@ -30,28 +30,28 @@ public class EmaTickDecayTest {
     }
 
     @Test
-    public void emaTickDecay1Group2Cols() {
+    public void emaTickDecay1Group1Col() {
         var q = "timed.update_by(ops=ema_tick_decay(time_scale_ticks=100,cols=['X=int5']), by=['str100'])";
-        runner.test("EmaTickDecay- 1 Group 100 Unique Vals 2 Col", runner.scaleRowCount, q, "str100", "int5");
+        runner.test("EmaTickDecay- 1 Group 100 Unique Vals 1 Col", runner.scaleRowCount, q, "str100", "int5");
     }
 
     @Test
-    public void emaTickDecay1Group3Cols() {
+    public void emaTickDecay1Group2Cols() {
         var q = "timed.update_by(ops=ema_tick_decay(time_scale_ticks=100,cols=['X=int5','Y=int10']), by=['str100'])";
-        runner.test("EmaTickDecay- 1 Group 100 Unique Vals 3 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
+        runner.test("EmaTickDecay- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5", "int10");
     }
 
     @Test
     public void emaTickDecay2GroupsInt() {
         var q = "timed.update_by(ops=ema_tick_decay(time_scale_ticks=100,cols=['X=int5']), by=['str100','str150'])";
-        runner.test("EmaTickDecay- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("EmaTickDecay- 2 Groups 15K Unique Combos 1 Col Int", runner.scaleRowCount, q, "str100", "str150",
                 "int5");
     }
 
     @Test
     public void emaTickDecay2GroupsFloat() {
         var q = "timed.update_by(ops=ema_tick_decay(time_scale_ticks=100,cols=['X=float5']), by=['str100','str150'])";
-        runner.test("EmaTickDecay- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("EmaTickDecay- 2 Groups 15K Unique Combos 1 Col Float", runner.scaleRowCount, q, "str100", "str150",
                 "float5");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTimeDecayTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTimeDecayTest.java
@@ -19,28 +19,28 @@ public class EmaTimeDecayTest {
     }
 
     @Test
-    public void emaTimeDecay0Group2Cols() {
+    public void emaTimeDecay0Group1Col() {
         var q = "timed.update_by(ops=ema_time_decay(ts_col='timestamp', time_scale='00:00:02', cols=['X=int5']))";
         runner.test("EmaTimeDecay- No Groups 1 Col", rowCount, q, "int5", "timestamp");
     }
 
     @Test
-    public void emaTimeDecay1Group3Cols() {
+    public void emaTimeDecay1Group1Col() {
         var q = "timed.update_by(ops=ema_time_decay(ts_col='timestamp', time_scale='00:00:02', cols=['X=int5']), by=['str100'])";
-        runner.test("EmaTimeDecay- 1 Group 100 Unique Vals 2 Col", rowCount, q, "str100", "int5", "timestamp");
+        runner.test("EmaTimeDecay- 1 Group 100 Unique Vals 1 Col", rowCount, q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void emaTimeDecay2GroupsInt() {
         var q = "timed.update_by(ops=ema_time_decay(ts_col='timestamp', time_scale='00:00:02', cols=['X=int5']), by=['str100','str150'])";
-        runner.test("EmaTickDecay- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("EmaTickDecay- 2 Groups 15K Unique Combos 1 Col Int", runner.scaleRowCount, q, "str100", "str150",
                 "int5", "timestamp");
     }
     
     @Test
     public void emaTimeDecay2GroupsFloat() {
         var q = "timed.update_by(ops=ema_time_decay(ts_col='timestamp', time_scale='00:00:02', cols=['X=float5']), by=['str100','str150'])";
-        runner.test("EmaTickDecay- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("EmaTickDecay- 2 Groups 15K Unique Combos 1 Col Float", runner.scaleRowCount, q, "str100", "str150",
                 "float5", "timestamp");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/MixedComboTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/MixedComboTest.java
@@ -1,0 +1,66 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Combines a mixture of rolling operations and cumulative operations
+ */
+public class MixedComboTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+    final long rowCount = runner.scaleRowCount;
+    String setupStr = null;
+
+    @BeforeEach
+    public void setup() {
+        runner.tables("timed");
+
+        setupStr = """
+        from deephaven.updateby import rolling_avg_time, rolling_max_tick, rolling_prod_time
+        from deephaven.updateby import ema_tick_decay, cum_min, cum_sum
+         
+        avg_contains = rolling_avg_time(ts_col="timestamp", cols=["U=${calc.col}"], rev_time="00:00:01", fwd_time="00:00:01")
+        max_before = rolling_max_tick(cols=["V = ${calc.col}"], rev_ticks=3, fwd_ticks=-1)
+        prod_after = rolling_prod_time(ts_col="timestamp", cols=["W=${calc.col}"], rev_time="-00:00:01", fwd_time=int(3e9))
+        
+        ema_tick_op = ema_tick_decay(time_scale_ticks=100,cols=['X=${calc.col}'])
+        min_op = cum_min(cols=['Y=${calc.col}'])
+        sum_op = cum_sum(cols=['Z=${calc.col}'])
+        """;
+    }
+
+    @Test
+    public void mixedComboNoGroups6Ops() {
+        runner.addSetupQuery(operations("int5"));
+        var q = "timed.update_by(ops=[avg_contains, max_before, prod_after, ema_tick_op, min_op, sum_op])";
+        runner.test("MixedCombo- 6 Ops No Groups", rowCount, q, "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingCombo2Groups6OpsInt() {
+        runner.addSetupQuery(operations("int5"));
+        var q = """
+        timed.update_by(ops=[avg_contains, max_before, prod_after, ema_tick_op, min_op, sum_op], 
+            by=['str100','str150'])
+        """;
+        runner.test("MixedCombo- 6 Ops 2 Groups 15K Unique Combos Int", rowCount, q, "str100", "str150",
+                "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingCombo2Groups6OpsFloat() {
+        runner.addSetupQuery(operations("float5"));
+        var q = """
+        timed.update_by(ops=[avg_contains, max_before, prod_after, ema_tick_op, min_op, sum_op], 
+            by=['str100','str150'])
+        """;
+        runner.test("MixedCombo- 6 Ops 2 Groups 15K Unique Combos Float", rowCount, q, "str100", "str150",
+                "float5", "timestamp");
+    }
+
+    private String operations(String type) {
+        return setupStr.replace("${calc.col}", type);
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTickTest.java
@@ -25,21 +25,21 @@ public class RollingAvgTickTest {
     }
 
     @Test
-    public void rollingAvgTick0Group1Col() {
+    public void rollingAvgTick0Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
-        runner.test("RollingAvgTick- No Groups 1 Cols", runner.scaleRowCount, q, "int5");
+        runner.test("RollingAvgTick- 3 Ops No Groups", runner.scaleRowCount, q, "int5");
     }
 
     @Test
-    public void rollingAvgTick1Group2Cols() {
+    public void rollingAvgTick1Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
-        runner.test("RollingAvgTick- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
+        runner.test("RollingAvgTick- 3 Ops 1 Group 100 Unique Vals", runner.scaleRowCount, q, "str100", "int5");
     }
 
     @Test
     public void rollingAvgTime2Groups3OpsInt() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingAvgTick- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("RollingAvgTick- 3 Ops 2 Groups 15K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
                 "int5");
     }
 
@@ -53,7 +53,7 @@ public class RollingAvgTickTest {
         runner.addSetupQuery(setup);
         
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingAvgTick- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("RollingAvgTick- 3 Ops 2 Groups 15K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
                 "float5");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTickTest.java
@@ -1,0 +1,60 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a tick-based rolling average. The result table contains
+ * additional columns with windowed rolling averages for each specified column in the source table.
+ */
+public class RollingAvgTickTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_avg_tick
+        contains_row = rolling_avg_tick(cols=["Contains = int5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_avg_tick(cols=["Before = int5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_avg_tick(cols=["After = int5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingAvgTick0Group1Col() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingAvgTick- No Groups 1 Cols", runner.scaleRowCount, q, "int5");
+    }
+
+    @Test
+    public void rollingAvgTick1Group2Cols() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingAvgTick- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
+    }
+
+    @Test
+    public void rollingAvgTime2Groups3OpsInt() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingAvgTick- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
+                "int5");
+    }
+
+    @Test
+    public void rollingAvgTick2Groups3OpsFloat() {
+        var setup = """
+        contains_row = rolling_avg_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_avg_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_avg_tick(cols=["After = float5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+        
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingAvgTick- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
+                "float5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTimeTest.java
@@ -1,0 +1,62 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a time-based rolling average. The result table contains
+ * additional columns with windowed rolling averages for each specified column in the source table.
+ */
+public class RollingAvgTimeTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+    final long rowCount = runner.scaleRowCount;
+
+    @BeforeEach
+    public void setup() {
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_avg_time
+        contains_row = rolling_avg_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_avg_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_avg_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingAvgTime0Group2Cols() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingAvgTime- No Groups 2 Cols", rowCount, q, "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingAvgTime1Group3Cols() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingAvgTime- 1 Group 100 Unique Vals 3 Cols", rowCount, q, "str100", "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingAvgTime2Groups3OpsInt() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingAvgTime- 2 Groups 160K Unique Combos Int", rowCount, q, "str100", "str150",
+                "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingAvgTime2Groups3OpsFloat() {
+        var setup = """
+        contains_row = rolling_avg_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_avg_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_avg_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        """;
+        runner.addSetupQuery(setup);
+
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingAvgTime- 2 Groups 160K Unique Combos Float", rowCount, q, "str100", "str150",
+                "float5", "timestamp");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTimeTest.java
@@ -27,21 +27,21 @@ public class RollingAvgTimeTest {
     }
 
     @Test
-    public void rollingAvgTime0Group2Cols() {
+    public void rollingAvgTime0Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
-        runner.test("RollingAvgTime- No Groups 2 Cols", rowCount, q, "int5", "timestamp");
+        runner.test("RollingAvgTime- 3 Ops No Groups", rowCount, q, "int5", "timestamp");
     }
 
     @Test
-    public void rollingAvgTime1Group3Cols() {
+    public void rollingAvgTime1Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
-        runner.test("RollingAvgTime- 1 Group 100 Unique Vals 3 Cols", rowCount, q, "str100", "int5", "timestamp");
+        runner.test("RollingAvgTime- 3 Ops 1 Group 100 Unique Vals", rowCount, q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void rollingAvgTime2Groups3OpsInt() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingAvgTime- 2 Groups 160K Unique Combos Int", rowCount, q, "str100", "str150",
+        runner.test("RollingAvgTime- 3 Ops 2 Groups 15K Unique Combos Int", rowCount, q, "str100", "str150",
                 "int5", "timestamp");
     }
 
@@ -55,7 +55,7 @@ public class RollingAvgTimeTest {
         runner.addSetupQuery(setup);
 
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingAvgTime- 2 Groups 160K Unique Combos Float", rowCount, q, "str100", "str150",
+        runner.test("RollingAvgTime- 3 Ops 2 Groups 15K Unique Combos Float", rowCount, q, "str100", "str150",
                 "float5", "timestamp");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingComboTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingComboTest.java
@@ -5,37 +5,62 @@ import org.junit.jupiter.api.*;
 import io.deephaven.benchmark.tests.standard.StandardTestRunner;
 
 /**
- * Standard tests for the updateBy table operation. Combines multiple rolling operations
+ * Standard tests for the updateBy table operation. Combines multiple rolling operations for tick and time windows
  */
 public class RollingComboTest {
     final StandardTestRunner runner = new StandardTestRunner(this);
     final long rowCount = runner.scaleRowCount;
+    String setupStr = null;
 
     @BeforeEach
     public void setup() {
         runner.tables("timed");
-
-        var setup = """
-        from deephaven.updateby import rolling_sum_time, cum_sum, rolling_avg_time, rolling_sum_tick
-        contains_row = rolling_sum_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_sum_tick(cols=["Y=int5"], rev_ticks=3, fwd_ticks=-1)
-        after_row = rolling_avg_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
         
+        setupStr = """
+        from deephaven.updateby import rolling_sum_time, rolling_min_time, rolling_prod_time
+        from deephaven.updateby import rolling_avg_tick, rolling_max_tick, rolling_group_tick
+         
+        sum_contains = rolling_sum_time(ts_col="timestamp", cols=["U=${calc.col}"], rev_time="00:00:01", fwd_time="00:00:01")
+        min_before = rolling_min_time(ts_col="timestamp", cols=["V=${calc.col}"], rev_time="00:00:03", fwd_time=int(-1e9))
+        prod_after = rolling_prod_time(ts_col="timestamp", cols=["W=${calc.col}"], rev_time="-00:00:01", fwd_time=int(3e9))
+        
+        avg_contains = rolling_avg_tick(cols=["X = ${calc.col}"], rev_ticks=1, fwd_ticks=1)
+        max_before = rolling_max_tick(cols=["Y = ${calc.col}"], rev_ticks=3, fwd_ticks=-1)
+        group_after = rolling_group_tick(cols=["Z = ${calc.col}"], rev_ticks=-1, fwd_ticks=3)
         """;
-        runner.addSetupQuery(setup);
     }
 
     @Test
-    public void rollingCombo4OpsNoGroups() {
-        var q = "timed.update_by(ops=[contains_row, before_row, after_row, cum_sum(cols=['W=int5'])])";
-        runner.test("RollingCombo- 4 Calcs No Groups", rowCount, q, "int5", "timestamp");
+    public void rollingComboNoGroups6Ops() {
+        runner.addSetupQuery(operations("int5"));
+        var q = "timed.update_by(ops=[sum_contains, min_before, prod_after, avg_contains, max_before, group_after])";
+        runner.test("RollingCombo- 6 Ops No Groups", rowCount, q, "int5", "timestamp");
     }
 
     @Test
-    public void rollingCombo4Ops2Groups() {
-        var q = "timed.update_by(ops=[contains_row, before_row, after_row, cum_sum(cols=['W=int5'])], by=['str100','str150'])";
-        runner.test("RollingCombo- 2 Groups 4 Ops Int 160K Unique Combos", rowCount, q, "str100", "str150",
-                "int5", "timestamp");
+    public void rollingCombo2Groups6OpsInt() {
+        runner.addSetupQuery(operations("int5"));
+        var q = """
+        timed.update_by(ops=[sum_contains, min_before, prod_after, avg_contains, max_before, group_after], 
+            by=['str100','str150']);
+        """;
+        runner.test("RollingCombo- 6 Ops 2 Groups 15K Unique Combos Int", rowCount, q, "str100", "str150", "int5",
+                "timestamp");
+    }
+
+    @Test
+    public void rollingCombo2Groups6OpsFloat() {
+        runner.addSetupQuery(operations("float5"));
+        var q = """
+        timed.update_by(ops=[sum_contains, min_before, prod_after, avg_contains, max_before, group_after], 
+            by=['str100','str150']);
+        """;
+        runner.test("RollingCombo- 6 Ops 2 Groups 15K Unique Combos Float", rowCount, q, "str100", "str150", "float5",
+                "timestamp");
+    }
+    
+    private String operations(String type) {
+        return setupStr.replace("${calc.col}", type);
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingComboTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingComboTest.java
@@ -15,12 +15,11 @@ public class RollingComboTest {
     public void setup() {
         runner.tables("timed");
 
-        // TODO: Replace duplicate rolling sum with average when ready
         var setup = """
-        from deephaven.updateby import rolling_sum_time, cum_sum, rolling_sum_time, rolling_sum_tick
+        from deephaven.updateby import rolling_sum_time, cum_sum, rolling_avg_time, rolling_sum_tick
         contains_row = rolling_sum_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
         before_row = rolling_sum_tick(cols=["Y=int5"], rev_ticks=3, fwd_ticks=-1)
-        after_row = rolling_sum_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        after_row = rolling_avg_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
         
         """;
         runner.addSetupQuery(setup);

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingGroupTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingGroupTickTest.java
@@ -1,0 +1,60 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a tick-based rolling group. The result table contains
+ * additional columns with windowed rolling groups for each specified column in the source table.
+ */
+public class RollingGroupTickTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_group_tick
+        contains_row = rolling_group_tick(cols=["Contains = int5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_group_tick(cols=["Before = int5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_group_tick(cols=["After = int5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingGroupTick0Group3Ops() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingGroupTick- 3 Ops No Groups", runner.scaleRowCount, q, "int5");
+    }
+
+    @Test
+    public void rollingGroupTick1Group3Ops() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingGroupTick- 3 Ops 1 Group 100 Unique Vals", runner.scaleRowCount, q, "str100", "int5");
+    }
+
+    @Test
+    public void rollingGroupTick2Groups3OpsInt() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingGroupTick- 3 Ops 2 Groups 15K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
+                "int5");
+    }
+
+    @Test
+    public void rollingGroupTick2Groups3OpsFloat() {
+        var setup = """
+        contains_row = rolling_group_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_group_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_group_tick(cols=["After = float5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+        
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingGroupTick- 3 Ops 2 Groups 15K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
+                "float5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingGroupTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingGroupTimeTest.java
@@ -1,0 +1,62 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a time-based rolling group. The result table contains
+ * additional columns with windowed rolling groups for each specified column in the source table.
+ */
+public class RollingGroupTimeTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+    final long rowCount = runner.scaleRowCount;
+
+    @BeforeEach
+    public void setup() {
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_group_time
+        contains_row = rolling_group_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_group_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_group_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingGroupTime0Group3Ops() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingGroupTime- 3 Ops No Groups", rowCount, q, "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingGroupTime1Group3Ops() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingGroupTime- 3 Ops 1 Group 100 Unique Vals", rowCount, q, "str100", "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingGroupTime2Groups3OpsInt() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingGroupTime- 3 Ops 2 Groups 15K Unique Combos Int", rowCount, q, "str100", "str150",
+                "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingGroupTime2Groups3OpsFloat() {
+        var setup = """
+        contains_row = rolling_group_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_group_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_group_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        """;
+        runner.addSetupQuery(setup);
+
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingGroupTime- 3 Ops 2 Groups 15K Unique Combos Float", rowCount, q, "str100", "str150",
+                "float5", "timestamp");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTickTest.java
@@ -1,0 +1,60 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a tick-based rolling maximum. The result table contains
+ * additional columns with windowed rolling maximum for each specified column in the source table.
+ */
+public class RollingMaxTickTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_max_tick
+        contains_row = rolling_max_tick(cols=["Contains = int5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_max_tick(cols=["Before = int5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_max_tick(cols=["After = int5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingMaxTick0Group1Col() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingMaxTick- No Groups 1 Cols", runner.scaleRowCount, q, "int5");
+    }
+
+    @Test
+    public void rollingMaxTick1Group2Cols() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingMaxTick- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
+    }
+
+    @Test
+    public void rollingMaxTick2Groups3OpsInt() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingMaxTick- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
+                "int5");
+    }
+
+    @Test
+    public void rollingMaxTick2Groups3OpsFloat() {
+        var setup = """
+        contains_row = rolling_max_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_max_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_max_tick(cols=["After = float5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+        
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingMaxTick- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
+                "float5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTickTest.java
@@ -25,21 +25,21 @@ public class RollingMaxTickTest {
     }
 
     @Test
-    public void rollingMaxTick0Group1Col() {
+    public void rollingMaxTick0Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
-        runner.test("RollingMaxTick- No Groups 1 Cols", runner.scaleRowCount, q, "int5");
+        runner.test("RollingMaxTick- 3 Ops No Groups", runner.scaleRowCount, q, "int5");
     }
 
     @Test
-    public void rollingMaxTick1Group2Cols() {
+    public void rollingMaxTick1Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
-        runner.test("RollingMaxTick- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
+        runner.test("RollingMaxTick- 3 Ops 1 Group 100 Unique Vals", runner.scaleRowCount, q, "str100", "int5");
     }
 
     @Test
     public void rollingMaxTick2Groups3OpsInt() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingMaxTick- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("RollingMaxTick- 3 Ops 2 Groups 15K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
                 "int5");
     }
 
@@ -53,7 +53,7 @@ public class RollingMaxTickTest {
         runner.addSetupQuery(setup);
         
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingMaxTick- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("RollingMaxTick- 3 Ops 2 Groups 15K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
                 "float5");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTimeTest.java
@@ -1,0 +1,62 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a time-based rolling maximum. The result table contains
+ * additional columns with windowed rolling maximums for each specified column in the source table.
+ */
+public class RollingMaxTimeTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+    final long rowCount = runner.scaleRowCount;
+
+    @BeforeEach
+    public void setup() {
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_max_time
+        contains_row = rolling_max_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_max_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_max_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingMaxTime0Group2Cols() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingMaxTime- No Groups 2 Cols", rowCount, q, "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingMaxTime1Group3Cols() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingMaxTime- 1 Group 100 Unique Vals 3 Cols", rowCount, q, "str100", "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingMaxTime2Groups3OpsInt() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingMaxTime- 2 Groups 160K Unique Combos Int", rowCount, q, "str100", "str150",
+                "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingMaxTime2Groups3OpsFloat() {
+        var setup = """
+        contains_row = rolling_max_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_max_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_max_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        """;
+        runner.addSetupQuery(setup);
+
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingMaxTime- 2 Groups 160K Unique Combos Float", rowCount, q, "str100", "str150",
+                "float5", "timestamp");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTimeTest.java
@@ -27,21 +27,21 @@ public class RollingMaxTimeTest {
     }
 
     @Test
-    public void rollingMaxTime0Group2Cols() {
+    public void rollingMaxTime0Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
-        runner.test("RollingMaxTime- No Groups 2 Cols", rowCount, q, "int5", "timestamp");
+        runner.test("RollingMaxTime- 3 Ops No Groups", rowCount, q, "int5", "timestamp");
     }
 
     @Test
-    public void rollingMaxTime1Group3Cols() {
+    public void rollingMaxTime1Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
-        runner.test("RollingMaxTime- 1 Group 100 Unique Vals 3 Cols", rowCount, q, "str100", "int5", "timestamp");
+        runner.test("RollingMaxTime- 3 Ops 1 Group 100 Unique Vals", rowCount, q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void rollingMaxTime2Groups3OpsInt() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingMaxTime- 2 Groups 160K Unique Combos Int", rowCount, q, "str100", "str150",
+        runner.test("RollingMaxTime- 3 Ops 2 Groups 15K Unique Combos Int", rowCount, q, "str100", "str150",
                 "int5", "timestamp");
     }
 
@@ -55,7 +55,7 @@ public class RollingMaxTimeTest {
         runner.addSetupQuery(setup);
 
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingMaxTime- 2 Groups 160K Unique Combos Float", rowCount, q, "str100", "str150",
+        runner.test("RollingMaxTime- 3 Ops 2 Groups 15K Unique Combos Float", rowCount, q, "str100", "str150",
                 "float5", "timestamp");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTickTest.java
@@ -25,21 +25,21 @@ public class RollingMinTickTest {
     }
 
     @Test
-    public void rollingMinTick0Group1Col() {
+    public void rollingMinTick0Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
-        runner.test("RollingMinTick- No Groups 1 Cols", runner.scaleRowCount, q, "int5");
+        runner.test("RollingMinTick- 3 Ops No Groups", runner.scaleRowCount, q, "int5");
     }
 
     @Test
-    public void rollingMinTick1Group2Cols() {
+    public void rollingMinTick1Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
-        runner.test("RollingMinTick- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
+        runner.test("RollingMinTick- 3 Ops 1 Group 100 Unique Vals", runner.scaleRowCount, q, "str100", "int5");
     }
 
     @Test
     public void rollingMinTick2Groups3OpsInt() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingMinTick- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("RollingMinTick- 3 Ops 2 Groups 15K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
                 "int5");
     }
 
@@ -53,7 +53,7 @@ public class RollingMinTickTest {
         runner.addSetupQuery(setup);
         
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingMinTick- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("RollingMinTick- 3 Ops 2 Groups 15K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
                 "float5");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTickTest.java
@@ -1,0 +1,60 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a tick-based rolling minimum. The result table contains
+ * additional columns with windowed rolling minimums for each specified column in the source table.
+ */
+public class RollingMinTickTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_min_tick
+        contains_row = rolling_min_tick(cols=["Contains = int5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_min_tick(cols=["Before = int5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_min_tick(cols=["After = int5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingMinTick0Group1Col() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingMinTick- No Groups 1 Cols", runner.scaleRowCount, q, "int5");
+    }
+
+    @Test
+    public void rollingMinTick1Group2Cols() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingMinTick- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
+    }
+
+    @Test
+    public void rollingMinTick2Groups3OpsInt() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingMinTick- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
+                "int5");
+    }
+
+    @Test
+    public void rollingMinTick2Groups3OpsFloat() {
+        var setup = """
+        contains_row = rolling_min_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_min_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_min_tick(cols=["After = float5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+        
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingMinTick- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
+                "float5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTimeTest.java
@@ -27,21 +27,21 @@ public class RollingMinTimeTest {
     }
 
     @Test
-    public void rollingMinTime0Group2Cols() {
+    public void rollingMinTime0Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
-        runner.test("RollingMinTime- No Groups 2 Cols", rowCount, q, "int5", "timestamp");
+        runner.test("RollingMinTime- 3 Ops No Groups", rowCount, q, "int5", "timestamp");
     }
 
     @Test
-    public void rollingMinTime1Group3Cols() {
+    public void rollingMinTime1Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
-        runner.test("RollingMinTime- 1 Group 100 Unique Vals 3 Cols", rowCount, q, "str100", "int5", "timestamp");
+        runner.test("RollingMinTime- 3 Ops 1 Group 100 Unique Vals", rowCount, q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void rollingMinTime2Groups3OpsInt() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingMinTime- 2 Groups 160K Unique Combos Int", rowCount, q, "str100", "str150",
+        runner.test("RollingMinTime- 3 Ops 2 Groups 15K Unique Combos Int", rowCount, q, "str100", "str150",
                 "int5", "timestamp");
     }
 
@@ -55,7 +55,7 @@ public class RollingMinTimeTest {
         runner.addSetupQuery(setup);
 
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingMinTime- 2 Groups 160K Unique Combos Float", rowCount, q, "str100", "str150",
+        runner.test("RollingMinTime- 3 Ops 2 Groups 15K Unique Combos Float", rowCount, q, "str100", "str150",
                 "float5", "timestamp");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTimeTest.java
@@ -1,0 +1,62 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a time-based rolling minimum. The result table contains
+ * additional columns with windowed rolling minimums for each specified column in the source table.
+ */
+public class RollingMinTimeTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+    final long rowCount = runner.scaleRowCount;
+
+    @BeforeEach
+    public void setup() {
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_min_time
+        contains_row = rolling_min_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_min_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_min_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingMinTime0Group2Cols() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingMinTime- No Groups 2 Cols", rowCount, q, "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingMinTime1Group3Cols() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingMinTime- 1 Group 100 Unique Vals 3 Cols", rowCount, q, "str100", "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingMinTime2Groups3OpsInt() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingMinTime- 2 Groups 160K Unique Combos Int", rowCount, q, "str100", "str150",
+                "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingMinTime2Groups3OpsFloat() {
+        var setup = """
+        contains_row = rolling_min_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_min_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_min_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        """;
+        runner.addSetupQuery(setup);
+
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingMinTime- 2 Groups 160K Unique Combos Float", rowCount, q, "str100", "str150",
+                "float5", "timestamp");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTickTest.java
@@ -1,0 +1,60 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a tick-based rolling product. The result table contains
+ * additional columns with windowed rolling product for each specified column in the source table.
+ */
+public class RollingProdTickTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_prod_tick
+        contains_row = rolling_prod_tick(cols=["Contains = int5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_prod_tick(cols=["Before = int5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_prod_tick(cols=["After = int5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingProdTick0Group1Col() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingProdTick- No Groups 1 Cols", runner.scaleRowCount, q, "int5");
+    }
+
+    @Test
+    public void rollingProdTick1Group2Cols() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingProdTick- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
+    }
+
+    @Test
+    public void rollingProdTick2Groups3OpsInt() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingProdTick- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
+                "int5");
+    }
+
+    @Test
+    public void rollingProdTick2Groups3OpsFloat() {
+        var setup = """
+        contains_row = rolling_prod_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_prod_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_prod_tick(cols=["After = float5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+        
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingProdTick- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
+                "float5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTickTest.java
@@ -25,21 +25,21 @@ public class RollingProdTickTest {
     }
 
     @Test
-    public void rollingProdTick0Group1Col() {
+    public void rollingProdTick0Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
-        runner.test("RollingProdTick- No Groups 1 Cols", runner.scaleRowCount, q, "int5");
+        runner.test("RollingProdTick- 3 Ops No Groups", runner.scaleRowCount, q, "int5");
     }
 
     @Test
-    public void rollingProdTick1Group2Cols() {
+    public void rollingProdTick1Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
-        runner.test("RollingProdTick- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
+        runner.test("RollingProdTick- 3 Ops 1 Group 100 Unique Vals", runner.scaleRowCount, q, "str100", "int5");
     }
 
     @Test
     public void rollingProdTick2Groups3OpsInt() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingProdTick- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("RollingProdTick- 3 Ops 2 Groups 15K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
                 "int5");
     }
 
@@ -53,7 +53,7 @@ public class RollingProdTickTest {
         runner.addSetupQuery(setup);
         
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingProdTick- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("RollingProdTick- 3 Ops 2 Groups 15K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
                 "float5");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTimeTest.java
@@ -27,21 +27,21 @@ public class RollingProdTimeTest {
     }
 
     @Test
-    public void rollingProdTime0Group2Cols() {
+    public void rollingProdTime0Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
-        runner.test("RollingProdTime- No Groups 2 Cols", rowCount, q, "int5", "timestamp");
+        runner.test("RollingProdTime- 3 Ops No Groups", rowCount, q, "int5", "timestamp");
     }
 
     @Test
-    public void rollingProdTime1Group3Cols() {
+    public void rollingProdTime1Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
-        runner.test("RollingProdTime- 1 Group 100 Unique Vals 3 Cols", rowCount, q, "str100", "int5", "timestamp");
+        runner.test("RollingProdTime- 3 Ops 1 Group 100 Unique Vals", rowCount, q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void rollingProdTime2Groups3OpsInt() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingProdTime- 2 Groups 160K Unique Combos Int", rowCount, q, "str100", "str150",
+        runner.test("RollingProdTime- 3 Ops 2 Groups 15K Unique Combos Int", rowCount, q, "str100", "str150",
                 "int5", "timestamp");
     }
 
@@ -55,7 +55,7 @@ public class RollingProdTimeTest {
         runner.addSetupQuery(setup);
 
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingProdTime- 2 Groups 160K Unique Combos Float", rowCount, q, "str100", "str150",
+        runner.test("RollingProdTime- 3 Ops 2 Groups 15K Unique Combos Float", rowCount, q, "str100", "str150",
                 "float5", "timestamp");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTimeTest.java
@@ -1,0 +1,62 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a time-based rolling product. The result table contains
+ * additional columns with windowed rolling products for each specified column in the source table.
+ */
+public class RollingProdTimeTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+    final long rowCount = runner.scaleRowCount;
+
+    @BeforeEach
+    public void setup() {
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_prod_time
+        contains_row = rolling_prod_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_prod_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_prod_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingProdTime0Group2Cols() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingProdTime- No Groups 2 Cols", rowCount, q, "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingProdTime1Group3Cols() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingProdTime- 1 Group 100 Unique Vals 3 Cols", rowCount, q, "str100", "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingProdTime2Groups3OpsInt() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingProdTime- 2 Groups 160K Unique Combos Int", rowCount, q, "str100", "str150",
+                "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingProdTime2Groups3OpsFloat() {
+        var setup = """
+        contains_row = rolling_prod_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_prod_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_prod_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        """;
+        runner.addSetupQuery(setup);
+
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingProdTime- 2 Groups 160K Unique Combos Float", rowCount, q, "str100", "str150",
+                "float5", "timestamp");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTickTest.java
@@ -25,21 +25,21 @@ public class RollingSumTickTest {
     }
 
     @Test
-    public void rollingSumTick0Group1Col() {
+    public void rollingSumTick0Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
-        runner.test("RollingSumTick- No Groups 1 Cols", runner.scaleRowCount, q, "int5");
+        runner.test("RollingSumTick- 3 Ops No Groups", runner.scaleRowCount, q, "int5");
     }
 
     @Test
-    public void rollingSumTick1Group2Cols() {
+    public void rollingSumTick1Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
-        runner.test("RollingSumTick- 1 Group 100 Unique Vals 2 Cols", runner.scaleRowCount, q, "str100", "int5");
+        runner.test("RollingSumTick- 3 Ops 1 Group 100 Unique Vals", runner.scaleRowCount, q, "str100", "int5");
     }
 
     @Test
     public void rollingSumTick2Groups3OpsInt() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingSumTick- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("RollingSumTick- 3 Ops 2 Groups 15K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
                 "int5");
     }
 
@@ -53,7 +53,7 @@ public class RollingSumTickTest {
         runner.addSetupQuery(setup);
         
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingSumTick- 2 Groups 160K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
+        runner.test("RollingSumTick- 3 Ops 2 Groups 15K Unique Combos Float", runner.scaleRowCount, q, "str100", "str150",
                 "float5");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTickTest.java
@@ -37,7 +37,7 @@ public class RollingSumTickTest {
     }
 
     @Test
-    public void rollingSumTime2Groups3OpsInt() {
+    public void rollingSumTick2Groups3OpsInt() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
         runner.test("RollingSumTick- 2 Groups 160K Unique Combos Int", runner.scaleRowCount, q, "str100", "str150",
                 "int5");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTimeTest.java
@@ -27,21 +27,21 @@ public class RollingSumTimeTest {
     }
 
     @Test
-    public void rollingSumTime0Group2Cols() {
+    public void rollingSumTime0Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
-        runner.test("RollingSumTime- No Groups 2 Cols", rowCount, q, "int5", "timestamp");
+        runner.test("RollingSumTime- 3 Ops No Groups", rowCount, q, "int5", "timestamp");
     }
 
     @Test
-    public void rollingSumTime1Group3Cols() {
+    public void rollingSumTime1Group3Ops() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
-        runner.test("RollingSumTime- 1 Group 100 Unique Vals 3 Cols", rowCount, q, "str100", "int5", "timestamp");
+        runner.test("RollingSumTime- 3 Ops 1 Group 100 Unique Vals", rowCount, q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void rollingSumTime2Groups3OpsInt() {
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingSumTime- 2 Groups 160K Unique Combos Int", rowCount, q, "str100", "str150",
+        runner.test("RollingSumTime- 3 Ops 2 Groups 15K Unique Combos Int", rowCount, q, "str100", "str150",
                 "int5", "timestamp");
     }
 
@@ -55,7 +55,7 @@ public class RollingSumTimeTest {
         runner.addSetupQuery(setup);
 
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
-        runner.test("RollingSumTime- 2 Groups 160K Unique Combos Float", rowCount, q, "str100", "str150",
+        runner.test("RollingSumTime- 3 Ops 2 Groups 15K Unique Combos Float", rowCount, q, "str100", "str150",
                 "float5", "timestamp");
     }
 

--- a/src/main/java/io/deephaven/benchmark/api/Bench.java
+++ b/src/main/java/io/deephaven/benchmark/api/Bench.java
@@ -2,8 +2,6 @@
 package io.deephaven.benchmark.api;
 
 import java.io.Closeable;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -15,7 +13,6 @@ import java.util.concurrent.TimeUnit;
 import io.deephaven.benchmark.metric.Metrics;
 import io.deephaven.benchmark.util.Filer;
 import io.deephaven.benchmark.util.Ids;
-import io.deephaven.benchmark.util.Log;
 import io.deephaven.benchmark.util.Timer;
 
 /**
@@ -237,17 +234,6 @@ final public class Bench {
         if (!profile.isPropertyDefined("timestamp.test.results")) {
             System.setProperty("timestamp.test.results", "false");
         }
-    }
-
-    static boolean isTest(Object inst) {
-        for (Method m : inst.getClass().getMethods()) {
-            for (Annotation a : m.getAnnotations()) {
-                String str = a.toString();
-                if (str.matches(".*[.]Test[(].*"))
-                    return true;
-            }
-        }
-        return false;
     }
 
 }

--- a/src/main/java/io/deephaven/benchmark/api/BenchMetrics.java
+++ b/src/main/java/io/deephaven/benchmark/api/BenchMetrics.java
@@ -98,10 +98,10 @@ final public class BenchMetrics {
         var regex = "^init = ([-]?[0-9]+).* used = ([-]?[0-9]+).* committed = ([-]?[0-9]+).* max = ([-]?[0-9]+).*$";
         String[] vals = mvalue.replaceAll(regex, "$1,$2,$3,$4").split(",");
         if (vals.length == 4) {
-            metrics.set("Init", Long.parseLong(vals[0]), note);
-            metrics.set("Used", Long.parseLong(vals[1]), note);
-            metrics.set("Committed", Long.parseLong(vals[2]), note);
-            metrics.set("Max", Long.parseLong(vals[3]), note);
+            metrics.set(mname + " Init", Long.parseLong(vals[0]), note);
+            metrics.set(mname + " Used", Long.parseLong(vals[1]), note);
+            metrics.set(mname + " Committed", Long.parseLong(vals[2]), note);
+            metrics.set(mname + " Max", Long.parseLong(vals[3]), note);
         } else {
             metrics.set(mname, Numbers.parseNumber(mvalue), note);
         }

--- a/src/main/java/io/deephaven/benchmark/generator/AvroKafkaGenerator.java
+++ b/src/main/java/io/deephaven/benchmark/generator/AvroKafkaGenerator.java
@@ -101,25 +101,6 @@ public class AvroKafkaGenerator implements Generator {
     }
 
     /**
-     * Produce one record to a Kafka topic synchronously
-     * 
-     * @param row the data for a row in the form {col1=val1, col2=val2}
-     */
-    public void produce(Map<String, Object> row) {
-        checkClosed();
-        GenericRecord rec = new GenericData.Record(schema.rawSchema());
-        row.entrySet().stream().forEach(e -> {
-            rec.put(e.getKey(), e.getValue());
-        });
-
-        try {
-            producer.send(new ProducerRecord<>(topic, rec));
-        } catch (Exception ex) {
-            throw new RuntimeException("Failed to send to topic: " + topic + " record: " + row.toString(), ex);
-        }
-    }
-
-    /**
      * Close the producer and shutdown any async threads created during production
      */
     public void close() {

--- a/src/main/java/io/deephaven/benchmark/generator/Generator.java
+++ b/src/main/java/io/deephaven/benchmark/generator/Generator.java
@@ -1,14 +1,11 @@
 /* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.generator;
 
-import java.util.Map;
 import java.util.concurrent.Future;
 import io.deephaven.benchmark.metric.Metrics;
 
 public interface Generator {
     public Future<Metrics> produce(int perRecordPauseMillis, long maxRecordCount, int maxDurationSecs);
-
-    public void produce(Map<String, Object> row);
 
     public void close();
 }

--- a/src/main/java/io/deephaven/benchmark/generator/JsonKafkaGenerator.java
+++ b/src/main/java/io/deephaven/benchmark/generator/JsonKafkaGenerator.java
@@ -1,7 +1,6 @@
 /* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.generator;
 
-import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
 import org.apache.avro.generic.GenericRecord;
@@ -32,12 +31,6 @@ public class JsonKafkaGenerator implements Generator {
     public Future<Metrics> produce(int perRecordPauseSecs, long maxRecordCount, int maxDurationSecs) {
         // TODO Auto-generated method stub
         return null;
-    }
-
-    @Override
-    public void produce(Map<String, Object> row) {
-        // TODO Auto-generated method stub
-
     }
 
     @Override

--- a/src/main/java/io/deephaven/benchmark/generator/KafkaAdmin.java
+++ b/src/main/java/io/deephaven/benchmark/generator/KafkaAdmin.java
@@ -15,7 +15,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 
-public class KafkaAdmin {
+class KafkaAdmin {
     final Properties props;
 
     public KafkaAdmin(String bootstrapServers, String schemaRegistryUrl) {
@@ -30,11 +30,7 @@ public class KafkaAdmin {
         this.props = props;
     }
 
-    public KafkaAdmin(Properties props) {
-        this.props = props;
-    }
-
-    public void deleteTopic(String topic) {
+    void deleteTopic(String topic) {
         try (AdminClient admin = KafkaAdminClient.create(props)) {
             Set<String> names = admin.listTopics().names().get();
             if (names.contains(topic))
@@ -45,7 +41,7 @@ public class KafkaAdmin {
         }
     }
 
-    public Set<String> getTopics() {
+    Set<String> getTopics() {
         try (AdminClient admin = KafkaAdminClient.create(props)) {
             return admin.listTopics().names().get();
         } catch (Exception ex) {
@@ -53,7 +49,7 @@ public class KafkaAdmin {
         }
     }
 
-    public long getMessageCount(String topic) {
+    long getMessageCount(String topic) {
         try (KafkaConsumer<String, String> consumer = new KafkaConsumer<String, String>(props)) {
             List<TopicPartition> partitions =
                     consumer.partitionsFor(topic).stream().map(p -> new TopicPartition(topic, p.partition())).toList();

--- a/src/main/java/io/deephaven/benchmark/run/ResultSummary.java
+++ b/src/main/java/io/deephaven/benchmark/run/ResultSummary.java
@@ -12,17 +12,17 @@ import java.util.List;
 import io.deephaven.benchmark.api.Bench;
 import io.deephaven.benchmark.util.Ids;
 
-public class ResultSummary {
+class ResultSummary {
     static final String headerPrefix = "run-id";
     final Path rootDir;
     final Path summaryFile;
 
-    public ResultSummary(Path rootDir) {
+    ResultSummary(Path rootDir) {
         this.rootDir = rootDir;
         this.summaryFile = getSummaryFile(rootDir, "benchmark-summary-results.csv");
     }
 
-    public void summarize() {
+    void summarize() {
         if (!Files.exists(rootDir)) {
             System.out.println("Skipping summary because of missing output directory: " + rootDir);
         }


### PR DESCRIPTION
- Added rolling avg, min, max, prod, group tick/time tests
- Added combo tests for rolling, cum and mixed
- Fixed some test names to be more consistent

Even though there is some refactoring the bulk of this ticket is the new test files that were added.