### PR TITLE
Normalized support for origin for results and metrics. Parquet read/write tests.

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/experimental/ExperimentalTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/experimental/ExperimentalTestRunner.java
@@ -193,7 +193,7 @@ public class ExperimentalTestRunner {
                 rowCount.set((int) rcount);
             }).execute();
             api.awaitCompletion();
-            api.result().test(Duration.ofMillis(elapsedMillis.get()), scaleRowCount);
+            api.result().test("deephaven-engine", Duration.ofMillis(elapsedMillis.get()), scaleRowCount);
             return rowCount.get();
         } finally {
             api.close();

--- a/src/it/java/io/deephaven/benchmark/tests/experimental/trades/generated/UpdateTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/experimental/trades/generated/UpdateTest.java
@@ -25,7 +25,7 @@ public class UpdateTest {
     @Test
     public void update2CalcsUsing2Cols() {
         var q = "quotes_g.update(formulas=['Mid=(Bid+Ask)/2', 'Spread=Ask-Bid'])";
-        runner.test("Update- 2 Cals Using 2 Cols", runner.getScaleRowCount(), q, "Sym", "Timestamp", "Bid", "Ask");
+        runner.test("Update- 2 Calcs Using 2 Cols", runner.getScaleRowCount(), q, "Sym", "Timestamp", "Bid", "Ask");
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/internal/examples/stream/JoinTablesFromKafkaStreamTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/examples/stream/JoinTablesFromKafkaStreamTest.java
@@ -101,7 +101,7 @@ public class JoinTablesFromKafkaStreamTest {
             assertEquals(scaleRowCount, recCount, "Wrong record count");
         }).execute();
         api.awaitCompletion();
-        api.result().test(tm, scaleRowCount);
+        api.result().test("deephaven-engine", tm, scaleRowCount);
     }
 
     /**
@@ -155,7 +155,7 @@ public class JoinTablesFromKafkaStreamTest {
             assertEquals(scaleRowCount, recCount, "Wrong record count");
         }).execute();
         api.awaitCompletion();
-        api.result().test(tm, scaleRowCount);
+        api.result().test("deephaven-engine", tm, scaleRowCount);
     }
 
     /**
@@ -181,7 +181,7 @@ public class JoinTablesFromKafkaStreamTest {
         var tm = api.timer();
         api.query(query).execute();
         api.awaitCompletion();
-        api.result().test(tm, scaleRowCount);
+        api.result().test("deephaven-engine", tm, scaleRowCount);
     }
 
     @AfterEach

--- a/src/it/java/io/deephaven/benchmark/tests/internal/examples/stream/JoinTablesFromParquetAndStreamTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/examples/stream/JoinTablesFromParquetAndStreamTest.java
@@ -79,7 +79,7 @@ public class JoinTablesFromParquetAndStreamTest {
         }).execute();
 
         api.awaitCompletion();
-        api.result().test(tm, scaleRowCount);
+        api.result().test("deephaven-engine", tm, scaleRowCount);
     }
 
     /**
@@ -138,7 +138,7 @@ public class JoinTablesFromParquetAndStreamTest {
         }).execute();
 
         api.awaitCompletion();
-        api.result().test(tm, scaleRowCount);
+        api.result().test("deephaven-engine", tm, scaleRowCount);
     }
 
     @AfterEach

--- a/src/it/java/io/deephaven/benchmark/tests/internal/metrics/MetricsCollectionTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/metrics/MetricsCollectionTest.java
@@ -68,7 +68,7 @@ public class MetricsCollectionTest {
         Path metricsFile = Bench.outputDir.resolve(Bench.metricsFileName);
         assertTrue(Files.exists(metricsFile), "Missing metrics output file");
         var lines = Files.lines(metricsFile).toList();
-        assertEquals("benchmark_name,timestamp,origin,category,type,name,value,note", lines.get(0), "Wrong csv header");
+        assertEquals("benchmark_name,origin,timestamp,category,type,name,value,note", lines.get(0), "Wrong csv header");
         assertTrue(lines.size() > 1, "CSV has no data");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -168,7 +168,7 @@ public class StandardTestRunner {
                 api.metrics().add(table);
             }).execute();
             api.awaitCompletion();
-            api.result().test(Duration.ofMillis(elapsedMillis.get()), scaleRowCount);
+            api.result().test("deephaven-engine", Duration.ofMillis(elapsedMillis.get()), scaleRowCount);
             return rowCount.get();
         } finally {
             api.close();

--- a/src/it/java/io/deephaven/benchmark/tests/standard/parquet/ParquetTestSetup.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/parquet/ParquetTestSetup.java
@@ -1,0 +1,60 @@
+package io.deephaven.benchmark.tests.standard.parquet;
+
+import io.deephaven.benchmark.api.Bench;
+import io.deephaven.benchmark.metric.Metrics;
+import io.deephaven.benchmark.util.Exec;
+import io.deephaven.benchmark.util.Timer;
+
+class ParquetTestSetup {
+    final public long scaleRowCount;
+    final Object testInst;
+    final Bench api;
+
+    ParquetTestSetup(Object testInst) {
+        this.testInst = testInst;
+        this.api = initialize(testInst);
+        this.scaleRowCount = api.propertyAsIntegral("scale.row.count", "100000");
+    }
+
+    void table(String name, String codec) {
+        if (!name.equals("compressed"))
+            throw new RuntimeException("Undefined table name: " + name);
+        generateCompressedTable(codec);
+    }
+
+    Bench initialize(Object testInst) {
+        var query = """
+        import time
+        from deephaven import new_table, garbage_collect
+        from deephaven.column import int_col, float_col
+        from deephaven.parquet import read, write
+        """;
+
+        Bench api = Bench.create(testInst);
+        restartDocker(api);
+        api.query(query).execute();
+        return api;
+    }
+
+    void restartDocker(Bench api) {
+        var timer = api.timer();
+        var dockerComposeFile = api.property("docker.compose.file", "");
+        Exec.restartDocker(dockerComposeFile);
+        var metrics = new Metrics(Timer.now(), "test-runner", "setup", "docker");
+        metrics.set("restart", timer.duration().toMillis(), "standard");
+        api.metrics().add(metrics);
+    }
+
+    void generateCompressedTable(String codec) {
+        api.table("compressed").random()
+                .add("str100K", "string", "SYM[1-100000]")
+                .add("str10K", "string", "SYM[1-10000]")
+                .add("long100K", "long", "[1-100000]")
+                .add("long10K", "long", "[1-10000]")
+                .add("double100K", "double", "[1-100000]")
+                .add("double10K", "double", "[1-10000]")
+                .withCompression(codec)
+                .generateParquet();
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/parquet/ReadCompressedParquetTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/parquet/ReadCompressedParquetTest.java
@@ -1,0 +1,93 @@
+package io.deephaven.benchmark.tests.standard.parquet;
+
+import static org.junit.jupiter.api.Assertions.*;
+import java.time.Duration;
+import org.junit.jupiter.api.*;
+
+/**
+ * Standard tests for the parquet.read table operation. Read raw generated table data from a parquet file for each
+ * compression codec Deephaven supports
+ */
+public class ReadCompressedParquetTest {
+    final ParquetTestSetup setup = new ParquetTestSetup(this);
+
+    @Test
+    public void readZstd() {
+        setup.table("compressed", "zstd");
+        setup.api.setName("ParquetRead- ZSTD 2 Strs 2 Longs 2 Dbls -Static");
+        runTest();
+    }
+
+    @Test
+    public void readLz4() {
+        setup.table("compressed", "lz4");
+        setup.api.setName("ParquetRead- LZ4 2 Strs 2 Longs 2 Dbls -Static");
+        runTest();
+    }
+
+    @Test
+    public void readLzo() {
+        setup.table("compressed", "lzo");
+        setup.api.setName("ParquetRead- LZO 2 Strs 2 Longs 2 Dbls -Static");
+        runTest();
+    }
+
+    @Test
+    public void readGzip() {
+        setup.table("compressed", "gzip");
+        setup.api.setName("ParquetRead- GZIP 2 Strs 2 Longs 2 Dbls -Static");
+        runTest();
+    }
+
+    @Test
+    public void readSnappy() {
+        setup.table("compressed", "snappy");
+        setup.api.setName("ParquetRead- SNAPPY 2 Strs 2 Longs 2 Dbls -Static");
+        runTest();
+    }
+
+    @Test
+    public void readNone() {
+        setup.table("compressed", "none");
+        setup.api.setName("ParquetRead- NONE Strs 2 Longs 2 Dbls -Static");
+        runTest();
+    }
+
+    @AfterEach
+    public void teardown() {
+        setup.api.close();
+    }
+
+    private void runTest() {
+        var query = """
+        result = read("/data/compressed.parquet").select()
+        garbage_collect()
+        
+        bench_api_metrics_snapshot()
+        begin_time = time.perf_counter_ns()
+
+        iterations = 9
+        for i in range(1,iterations):
+            result = read("/data/compressed.parquet").select()
+        
+        end_time = time.perf_counter_ns()
+        bench_api_metrics_snapshot()
+        standard_metrics = bench_api_metrics_collect()
+        
+        stats = new_table([
+            float_col("elapsed_millis", [(end_time - begin_time) / 1000000.0 / iterations]),
+            int_col("result_row_count", [result.size]),
+        ])
+        """;
+
+        setup.api.query(query).fetchAfter("stats", table -> {
+            long elapsedMillis = table.getSum("elapsed_millis").intValue();
+            long rcount = table.getSum("result_row_count").longValue();
+            assertEquals(setup.scaleRowCount, rcount, "Wrong loaded row count");
+            setup.api.result().test("deephaven-engine", Duration.ofMillis(elapsedMillis), setup.scaleRowCount);
+        }).fetchAfter("standard_metrics", table -> {
+            setup.api.metrics().add(table);
+        }).execute();
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/parquet/WriteCompressedParquetTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/parquet/WriteCompressedParquetTest.java
@@ -1,0 +1,97 @@
+package io.deephaven.benchmark.tests.standard.parquet;
+
+import static org.junit.jupiter.api.Assertions.*;
+import java.time.Duration;
+import org.junit.jupiter.api.*;
+
+/**
+ * Standard tests for the parquet.write table operation. Writes raw generated table data to a parquet file for each
+ * compression codec Deephaven supports
+ */
+public class WriteCompressedParquetTest {
+    final ParquetTestSetup setup = new ParquetTestSetup(this);
+
+    @Test
+    public void writeZstd() {
+        setup.table("compressed", "zstd");
+        setup.api.setName("ParquetWrite- ZSTD 2 Strs 2 Longs 2 Dbls -Static");
+        runTest("zstd");
+    }
+
+    @Test
+    public void writeLz4() {
+        setup.table("compressed", "lz4");
+        setup.api.setName("ParquetWrite- LZ4 2 Strs 2 Longs 2 Dbls -Static");
+        runTest("lz4");
+    }
+
+    @Test
+    public void writeLzo() {
+        setup.table("compressed", "lzo");
+        setup.api.setName("ParquetWrite- LZO 2 Strs 2 Longs 2 Dbls -Static");
+        runTest("lzo");
+    }
+
+    @Test
+    public void writeGzip() {
+        setup.table("compressed", "gzip");
+        setup.api.setName("ParquetWrite- GZIP 2 Strs 2 Longs 2 Dbls -Static");
+        runTest("gzip");
+    }
+
+    @Test
+    public void writeSnappy() {
+        setup.table("compressed", "snappy");
+        setup.api.setName("ParquetWrite- SNAPPY 2 Strs 2 Longs 2 Dbls -Static");
+        runTest("snappy");
+    }
+
+    @Test
+    public void writeNone() {
+        setup.api.setName("ParquetWrite- NONE Strs 2 Longs 2 Dbls -Static");
+        runTest("none");
+    }
+
+    @AfterEach
+    public void teardown() {
+        setup.api.close();
+    }
+
+    private void runTest(String codec) {
+        setup.table("compressed", codec);
+
+        var query = """
+        source = read("/data/compressed.parquet").select()
+        write(source, '/data/compression.out.parquet', compression_codec_name='${codec}')  # Ignore 1st write time
+        garbage_collect()
+        
+        bench_api_metrics_snapshot()
+        begin_time = time.perf_counter_ns()
+        
+        iterations = 2
+        for i in range(1,iterations):
+            write(source, '/data/compression.out.${codec}.parquet', compression_codec_name='${codec}')
+        
+        end_time = time.perf_counter_ns()
+        bench_api_metrics_snapshot()
+        standard_metrics = bench_api_metrics_collect()
+        
+        stats = new_table([
+            float_col("elapsed_millis", [(end_time - begin_time) / 1000000.0 / iterations]),
+            int_col("result_row_count", [source.size]),
+        ])
+        """;
+        codec = codec.equals("none") ? "uncompressed" : codec;
+        query = query.replace("${codec}", codec.toUpperCase());
+
+        setup.api.query(query).fetchAfter("stats", table -> {
+            long elapsedMillis = table.getSum("elapsed_millis").intValue();
+            long rcount = table.getSum("result_row_count").longValue();
+            assertEquals(setup.scaleRowCount, rcount, "Wrong loaded row count");
+            setup.api.result().test("deephaven-engine", Duration.ofMillis(elapsedMillis), setup.scaleRowCount);
+        }).fetchAfter("standard_metrics", table -> {
+            setup.api.metrics().add(table);
+        }).execute();
+    }
+
+}

--- a/src/main/java/io/deephaven/benchmark/api/Bench.java
+++ b/src/main/java/io/deephaven/benchmark/api/Bench.java
@@ -177,6 +177,8 @@ final public class Bench {
      * Finish all running tasks (e.g. queries, generators), close any I/O, and append any results to the file system
      */
     public void close() {
+        if (isClosed)
+            return;
         isClosed = true;
         for (Closeable c : closeables) {
             try {

--- a/src/main/java/io/deephaven/benchmark/api/BenchMetrics.java
+++ b/src/main/java/io/deephaven/benchmark/api/BenchMetrics.java
@@ -16,7 +16,7 @@ import io.deephaven.benchmark.util.Numbers;
  */
 final public class BenchMetrics {
     static final String[] header =
-            {"benchmark_name", "timestamp", "origin", "category", "type", "name", "value", "note"};
+            {"benchmark_name", "origin", "timestamp", "category", "type", "name", "value", "note"};
     final List<Metrics> metrics = new ArrayList<>();
     final Path file;
     private String name = null;
@@ -39,8 +39,8 @@ final public class BenchMetrics {
     public BenchMetrics add(ResultTable table) {
         assertColumnNames(table);
         for (int r = 0, rn = table.getRowCount(); r < rn; r++) {
-            var timestamp = table.getNumber(r, "timestamp").longValue();
             var origin = table.getValue(r, "origin").toString();
+            var timestamp = table.getNumber(r, "timestamp").longValue();
             var category = table.getValue(r, "category").toString();
             var type = formatType(table.getValue(r, "type").toString());
             var mname = table.getValue(r, "name").toString();

--- a/src/main/java/io/deephaven/benchmark/api/BenchResult.java
+++ b/src/main/java/io/deephaven/benchmark/api/BenchResult.java
@@ -15,9 +15,10 @@ import io.deephaven.benchmark.util.Timer;
  * API is closed after each test. The results focus on rates for the test run.
  */
 final public class BenchResult {
-    static final String[] header = {"name", "timestamp", "duration", "test-rate", "test-row-count"};
+    static final String[] header =
+            {"benchmark_name", "origin", "timestamp", "test_duration", "op_duration", "op_rate", "row_count"};
     final Timer timer;
-    final Map<String, Object> rates;
+    final Map<String, Object> rate;
     final Path file;
     private String name = null;
 
@@ -28,37 +29,41 @@ final public class BenchResult {
     BenchResult(Path parent, String resultFileName) {
         this.file = parent.resolve(resultFileName);
         this.timer = Timer.start();
-        this.rates = new LinkedHashMap<>();
-        initializeRates(rates);
+        this.rate = new LinkedHashMap<>();
+        initializeRates(rate);
     }
 
     /**
      * Record a test rate for this result instance
      * 
+     * @param the place where the measurement was collected
      * @param timer a started timer measuring the test
      * @param count the processed item count (e.g. rowCount)
      * @return this result instance
      */
-    public BenchResult test(Timer timer, long count) {
-        test(timer.duration(), count);
+    public BenchResult test(String origin, Timer timer, long count) {
+        test(origin, timer.duration(), count);
         return this;
     }
 
     /**
      * Record a test rate for this result instance
      * 
+     * @param origin the place where the measurement was collected
      * @param timer a started timer measuring the test
      * @param count the processed item count (e.g. rowCount)
      * @return this result instance
      */
-    public BenchResult test(Duration duration, long count) {
-        rates.put("test-rate", new Rate(duration, count));
-        rates.put("test-row-count", count);
+    public BenchResult test(String origin, Duration duration, long count) {
+        rate.put("origin", origin);
+        rate.put("op_duration", duration);
+        rate.put("row_count", count);
         return this;
     }
 
     /**
-     * Save the collected results to a csv file. Skip results where name starts with "#"
+     * Save the collected results to a csv file. Skip results where name starts with "#". If no user-specified test
+     * result has been supplied, calculate add a default based on time since test start
      */
     public void commit() {
         if (name.startsWith("#"))
@@ -68,13 +73,17 @@ final public class BenchResult {
         if (!hasHeader())
             writeLine(head, file);
 
-        var m = new HashMap<String, Object>(rates);
-        m.put("name", name);
+        ensureTestRate();
+
+        var m = new HashMap<String, Object>(rate);
+        m.put("benchmark_name", name);
         m.put("timestamp", timer.beginTime);
-        m.put("duration", format(toSeconds(timer.duration())));
+        m.put("test_duration", format(toSeconds(timer.duration())));
+        m.put("op_rate", toRate(m.get("op_duration"), m.get("row_count")));
+        m.put("op_duration", format(toSeconds((Duration) m.get("op_duration"))));
         Log.info("Result: %s", m);
         writeLine(head.stream().map(h -> m.get(h)).toList(), file);
-        initializeRates(rates);
+        initializeRates(rate);
     }
 
     void setName(String name) {
@@ -87,6 +96,12 @@ final public class BenchResult {
 
     private void initializeRates(Map<String, Object> rates) {
         Arrays.stream(header).forEach(h -> rates.put(h, 0)); // Preserve key order
+    }
+
+    private void ensureTestRate() {
+        if (!rate.get("row_count").equals(0))
+            return;
+        test("n/a", timer, Bench.profile.propertyAsIntegral("scale.row.count", "10000"));
     }
 
     static void writeLine(Collection<?> values, Path file) {
@@ -107,11 +122,8 @@ final public class BenchResult {
         return duration.toMillis() / 1000.0f;
     }
 
-    static record Rate(Duration duration, long rowCount) {
-        @Override
-        public String toString() {
-            return format(rowCount / toSeconds(duration));
-        }
+    static long toRate(Object duration, Object count) {
+        return (long) (((Number) count).longValue() / toSeconds((Duration) duration));
     }
 
 }

--- a/src/main/java/io/deephaven/benchmark/api/BenchTable.java
+++ b/src/main/java/io/deephaven/benchmark/api/BenchTable.java
@@ -83,7 +83,7 @@ final public class BenchTable implements Closeable {
     /**
      * Override the default compression codec for record generation and parquet
      * 
-     * @param codec the compression codec <code>(zstd | lz4 | gzip | none)</code>
+     * @param codec the compression codec <code>(zstd | lz4 | lzo | gzip | none)</code>
      * @return this instance
      */
     public BenchTable withCompression(String codec) {
@@ -210,7 +210,8 @@ final public class BenchTable implements Closeable {
         query = generatorDefValues + query;
 
         String codec = getCompression();
-        String compression = codec.equals("NONE") ? "" : String.format(", compression_codec_name='%s'", codec);
+        codec = codec.equals("NONE") ? "UNCOMPRESSED" : codec;
+        String compression = String.format(", compression_codec_name='%s'", codec);
 
         return query.replace("${table.name}", tableName)
                 .replace("${compression.codec}", compression)

--- a/src/main/java/io/deephaven/benchmark/generator/AvroKafkaGenerator.java
+++ b/src/main/java/io/deephaven/benchmark/generator/AvroKafkaGenerator.java
@@ -125,11 +125,21 @@ public class AvroKafkaGenerator implements Generator {
         props.put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class);
         props.put("schema.registry.url", schemaRegistryUrl);
         props.put(ACKS_CONFIG, "0");
-        props.put(COMPRESSION_TYPE_CONFIG, compression.toLowerCase());
+        props.put(COMPRESSION_TYPE_CONFIG, getCompression(compression));
         props.put(BATCH_SIZE_CONFIG, 16384 * 4);
         props.put(BUFFER_MEMORY_CONFIG, 32 * 1024 * 1024L * 4);
         props.put(LINGER_MS_CONFIG, 200);
         return new KafkaProducer<>(props);
+    }
+
+    private String getCompression(String codec) {
+        codec = codec.toLowerCase();
+        switch (codec) {
+            case "none", "gzip", "snappy", "lz4", "zstd":
+                return codec;
+            default:
+                return "snappy";
+        }
     }
 
     private void cleanupTopic(String bootstrapServers, String schemaRegistryUrl, String topic) {

--- a/src/main/java/io/deephaven/benchmark/run/BenchmarkMain.java
+++ b/src/main/java/io/deephaven/benchmark/run/BenchmarkMain.java
@@ -5,12 +5,29 @@ import java.nio.file.Paths;
 import org.junit.platform.console.ConsoleLauncher;
 import io.deephaven.benchmark.api.Bench;
 
+/**
+ * Main class for running the benchmark framework from the deephaven-benchmark artifact. This wraps the JUnit standalone
+ * console launcher.
+ * <p/>
+ * ex. java -Dbenchmark.profile=my-benchmark.properties -jar deephaven-benchmark-1.0-SNAPSHOT.jar -cp my-tests.jar -p
+ * my.tests
+ * <p/>
+ * In addition to running benchmark tests using the console launcher, this class creates a
+ * <code>benchmark-summary-results.csv</code> that is a merge of any per-run results files that match
+ * <code>results/run-[A-za-z0-9]+/benchmark-results.csv</code> relative to the working directory
+ */
 public class BenchmarkMain {
+    /**
+     * Main method for executing the benchmark framework from the command line. Accepts the same arguments as the JUnit
+     * standalone console launcher
+     * 
+     * @param args standalone console launcher arguments
+     */
     static public void main(String[] args) {
         System.exit(main1(args));
     }
 
-    static public int main1(String[] args) {
+    static int main1(String[] args) {
         setSystemProperties();
         int exitCode = ConsoleLauncher.execute(System.out, System.err, args).getExitCode();
         if (exitCode == 0) {

--- a/src/main/java/io/deephaven/benchmark/util/Exec.java
+++ b/src/main/java/io/deephaven/benchmark/util/Exec.java
@@ -18,9 +18,9 @@ public class Exec {
     static public void restartDocker(String dockerComposeFile) {
         if (dockerComposeFile.isBlank())
             return;
-        exec("docker compose -f " + dockerComposeFile + " down");
+        exec("sudo docker compose -f " + dockerComposeFile + " down");
         Threads.sleep(1000);
-        exec("docker compose -f " + dockerComposeFile + " up -d");
+        exec("sudo docker compose -f " + dockerComposeFile + " up -d");
         Threads.sleep(3000);
     }
 

--- a/src/test/java/io/deephaven/benchmark/api/BenchResultTest.java
+++ b/src/test/java/io/deephaven/benchmark/api/BenchResultTest.java
@@ -20,7 +20,7 @@ public class BenchResultTest {
         Files.deleteIfExists(result.file);
         assertFalse(Files.exists(result.file), "Result file exists: " + result.file);
 
-        result.test(timer(123), 1234);
+        result.test("deephaven-engine", timer(123), 1234);
         Thread.sleep(200);
         result.commit();
 
@@ -28,12 +28,14 @@ public class BenchResultTest {
 
         List<String[]> csv = getResult(result);
         assertEquals(2, csv.size(), "Wrong line count");
-        assertEquals("[name, timestamp, duration, test-rate, test-row-count]", Arrays.toString(csv.get(0)),
-                "Wrong header");
+        assertEquals("[benchmark_name, origin, timestamp, test_duration, op_duration, op_rate, row_count]",
+                Arrays.toString(csv.get(0)), "Wrong header");
         assertEquals("mytest", csv.get(1)[0], "Wrong name");
-        assertEquals(result.timer.beginTime, Long.parseLong(csv.get(1)[1]), "Wrong timestamp");
-        assertTrue(Float.parseFloat(csv.get(1)[2]) >= 0.200, "Wrong duration");
-        assertEquals(10032.5205f, Float.parseFloat(csv.get(1)[3]), 0.01, "Wrong test rate");
+        assertEquals("deephaven-engine", csv.get(1)[1], "Wrong origin");
+        assertEquals(result.timer.beginTime, Long.parseLong(csv.get(1)[2]), "Wrong timestamp");
+        assertTrue(Float.parseFloat(csv.get(1)[3]) >= 0.200f, "Wrong test duration" + csv.get(1)[3]);
+        assertTrue(Float.parseFloat(csv.get(1)[4]) >= 0.12f, "Wrong op duration: " + csv.get(1)[4]);
+        assertEquals(10032, Long.parseLong(csv.get(1)[5]), 0.01, "Wrong test rate");
     }
 
     @Test
@@ -44,21 +46,21 @@ public class BenchResultTest {
         Files.deleteIfExists(result.file);
         assertFalse(Files.exists(result.file), "Result file exists: " + result.file);
 
-        result.test(timer(123), 1234);
+        result.test("deephaven-engine", timer(123), 1234);
         result.commit();
 
         result = new BenchResult(parent, "test-result.csv");
         result.setName("mytest2");
 
-        result.test(timer(321), 2345);
+        result.test("deephaven-engine", timer(321), 2345);
         result.commit();
 
         assertTrue(Files.exists(result.file), "Missing result file: " + result.file);
 
         List<String[]> csv = getResult(result);
         assertEquals(3, csv.size(), "Wrong line count");
-        assertEquals("[name, timestamp, duration, test-rate, test-row-count]", Arrays.toString(csv.get(0)),
-                "Wrong header");
+        assertEquals("[benchmark_name, origin, timestamp, test_duration, op_duration, op_rate, row_count]",
+                Arrays.toString(csv.get(0)), "Wrong header");
         assertEquals("mytest", csv.get(1)[0], "Wrong name");
         assertEquals("mytest2", csv.get(2)[0], "Wrong name");
     }


### PR DESCRIPTION
- Normalized support for column origin in bench results and metrics to make it easier to join
- Added read/write parquet tests to standard for measuring compression performance