### PR TITLE
Updateby rollingWAvg and more 

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTickTest.java
@@ -1,0 +1,66 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Calculates a tick-based exponential moving maximum for specified
+ * columns and places the result into a new column for each row.
+ */
+public class EmMaxTickTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
+        runner.addSetupQuery("from deephaven.updateby import emmax_tick");
+    }
+
+    @Test
+    public void emMaxTick0Group1Col() {
+        runner.setScaleFactors(20, 12);
+        var q = "timed.update_by(ops=emmax_tick(time_scale_ticks=100,cols=['X=int5']))";
+        runner.test("EmMaxTick- No Groups 1 Col", q, "int5");
+    }
+
+    @Test
+    public void emMaxTick0Group2Cols() {
+        runner.setScaleFactors(10, 7);
+        var q = "timed.update_by(ops=emmax_tick(time_scale_ticks=100,cols=['X=int5','Y=int10']))";
+        runner.test("EmMaxTick- No Groups 2 Cols", q, "int5", "int10");
+    }
+
+    
+    @Test
+    public void emMaxTick1Group1Col() {
+        runner.setScaleFactors(7, 1);
+        var q = "timed.update_by(ops=emmax_tick(time_scale_ticks=100,cols=['X=int5']), by=['str100'])";
+        runner.test("EmMaxTick- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5");
+    }
+
+    @Test
+    public void emMaxTick1Group2Cols() {
+        runner.setScaleFactors(5, 1);
+        var q = "timed.update_by(ops=emmax_tick(time_scale_ticks=100,cols=['X=int5','Y=int10']), by=['str100'])";
+        runner.test("EmMaxTick- 1 Group 100 Unique Vals 2 Cols", q, "str100", "int5", "int10");
+    }
+
+    @Test
+    public void emMaxTick2GroupsInt() {
+        runner.setScaleFactors(5, 1);
+        var q = "timed.update_by(ops=emmax_tick(time_scale_ticks=100,cols=['X=int5']), by=['str100','str150'])";
+        runner.test("EmMaxTick- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
+                "int5");
+    }
+
+    @Test
+    public void emMaxTick2GroupsFloat() {
+        runner.setScaleFactors(5, 1);
+        var q = "timed.update_by(ops=emmax_tick(time_scale_ticks=100,cols=['X=float5']), by=['str100','str150'])";
+        runner.test("EmMaxTick- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
+                "float5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTimeTest.java
@@ -1,0 +1,47 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Calculates a time-based exponential moving maximum for specified
+ * columns and places the result into a new column for each row.
+ */
+public class EmMaxTimeTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
+        runner.addSetupQuery("from deephaven.updateby import emmax_time");
+    }
+
+    @Test
+    public void emMaxTime0Group1Col() {
+        var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', time_scale='00:00:02', cols=['X=int5']))";
+        runner.test("EmMaxTime- No Groups 1 Col", q, "int5", "timestamp");
+    }
+
+    @Test
+    public void emMaxTime1Group1Col() {
+        var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', time_scale='00:00:02', cols=['X=int5']), by=['str100'])";
+        runner.test("EmMaxTime- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5", "timestamp");
+    }
+
+    @Test
+    public void emMaxTime2GroupsInt() {
+        var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', time_scale='00:00:02', cols=['X=int5']), by=['str100','str150'])";
+        runner.test("EmMaxTime- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
+                "int5", "timestamp");
+    }
+
+    @Test
+    public void emMaxTime2GroupsFloat() {
+        var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', time_scale='00:00:02', cols=['X=float5']), by=['str100','str150'])";
+        runner.test("EmMaxTime- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
+                "float5", "timestamp");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTickTest.java
@@ -1,0 +1,65 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Calculates a tick-based exponential moving minimum for specified
+ * columns and places the result into a new column for each row.
+ */
+public class EmMinTickTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
+        runner.addSetupQuery("from deephaven.updateby import emmin_tick");
+    }
+
+    @Test
+    public void emMinTick0Group1Col() {
+        runner.setScaleFactors(20, 12);
+        var q = "timed.update_by(ops=emmin_tick(time_scale_ticks=100,cols=['X=int5']))";
+        runner.test("EmMinTick- No Groups 1 Col", q, "int5");
+    }
+
+    @Test
+    public void emMinTick0Group2Cols() {
+        runner.setScaleFactors(10, 7);
+        var q = "timed.update_by(ops=emmin_tick(time_scale_ticks=100,cols=['X=int5','Y=int10']))";
+        runner.test("EmMinTick- No Groups 2 Cols", q, "int5", "int10");
+    }
+
+    @Test
+    public void emMinTick1Group1Col() {
+        runner.setScaleFactors(7, 1);
+        var q = "timed.update_by(ops=emmin_tick(time_scale_ticks=100,cols=['X=int5']), by=['str100'])";
+        runner.test("EmMinTick- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5");
+    }
+
+    @Test
+    public void emMinTick1Group2Cols() {
+        runner.setScaleFactors(5, 1);
+        var q = "timed.update_by(ops=emmin_tick(time_scale_ticks=100,cols=['X=int5','Y=int10']), by=['str100'])";
+        runner.test("EmMinTick- 1 Group 100 Unique Vals 2 Cols", q, "str100", "int5", "int10");
+    }
+
+    @Test
+    public void emMinTick2GroupsInt() {
+        runner.setScaleFactors(5, 1);
+        var q = "timed.update_by(ops=emmin_tick(time_scale_ticks=100,cols=['X=int5']), by=['str100','str150'])";
+        runner.test("EmMinTick- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
+                "int5");
+    }
+
+    @Test
+    public void emMinTick2GroupsFloat() {
+        runner.setScaleFactors(5, 1);
+        var q = "timed.update_by(ops=emmin_tick(time_scale_ticks=100,cols=['X=float5']), by=['str100','str150'])";
+        runner.test("EmMinTick- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
+                "float5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTimeTest.java
@@ -1,0 +1,47 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Calculates a time-based exponential moving minimum for specified
+ * columns and places the result into a new column for each row.
+ */
+public class EmMinTimeTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
+        runner.addSetupQuery("from deephaven.updateby import emmin_time");
+    }
+
+    @Test
+    public void emMinTime0Group1Col() {
+        var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', time_scale='00:00:02', cols=['X=int5']))";
+        runner.test("EmMinTime- No Groups 1 Col", q, "int5", "timestamp");
+    }
+
+    @Test
+    public void emMinTime1Group1Col() {
+        var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', time_scale='00:00:02', cols=['X=int5']), by=['str100'])";
+        runner.test("EmMinTime- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5", "timestamp");
+    }
+
+    @Test
+    public void emMinTime2GroupsInt() {
+        var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', time_scale='00:00:02', cols=['X=int5']), by=['str100','str150'])";
+        runner.test("EmMinTime- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
+                "int5", "timestamp");
+    }
+
+    @Test
+    public void emMinTime2GroupsFloat() {
+        var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', time_scale='00:00:02', cols=['X=float5']), by=['str100','str150'])";
+        runner.test("EmMinTime- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
+                "float5", "timestamp");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTickTest.java
@@ -1,0 +1,65 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Calculates a tick-based exponential moving sum for specified
+ * columns and places the result into a new column for each row.
+ */
+public class EmsTickTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
+        runner.addSetupQuery("from deephaven.updateby import ems_tick");
+    }
+
+    @Test
+    public void emsTick0Group1Col() {
+        runner.setScaleFactors(30, 15);
+        var q = "timed.update_by(ops=ems_tick(time_scale_ticks=100,cols=['X=int5']))";
+        runner.test("EmsTick- No Groups 1 Col", q, "int5");
+    }
+
+    @Test
+    public void emsTick0Group2Cols() {
+        runner.setScaleFactors(15, 8);
+        var q = "timed.update_by(ops=ems_tick(time_scale_ticks=100,cols=['X=int5','Y=int10']))";
+        runner.test("EmsTick- No Groups 2 Cols", q, "int5", "int10");
+    }
+
+    @Test
+    public void emsTick1Group1Col() {
+        runner.setScaleFactors(9, 1);
+        var q = "timed.update_by(ops=ems_tick(time_scale_ticks=100,cols=['X=int5']), by=['str100'])";
+        runner.test("EmsTick- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5");
+    }
+
+    @Test
+    public void emsTick1Group2Cols() {
+        runner.setScaleFactors(5, 1);
+        var q = "timed.update_by(ops=ems_tick(time_scale_ticks=100,cols=['X=int5','Y=int10']), by=['str100'])";
+        runner.test("EmsTick- 1 Group 100 Unique Vals 2 Cols", q, "str100", "int5", "int10");
+    }
+
+    @Test
+    public void emsTick2GroupsInt() {
+        runner.setScaleFactors(5, 1);
+        var q = "timed.update_by(ops=ems_tick(time_scale_ticks=100,cols=['X=int5']), by=['str100','str150'])";
+        runner.test("EmsTick- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
+                "int5");
+    }
+
+    @Test
+    public void emsTick2GroupsFloat() {
+        runner.setScaleFactors(5, 1);
+        var q = "timed.update_by(ops=ems_tick(time_scale_ticks=100,cols=['X=float5']), by=['str100','str150'])";
+        runner.test("EmsTick- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
+                "float5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTimeTest.java
@@ -1,0 +1,47 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Calculates a time-based exponential moving average for specified
+ * columns and places the result into a new column for each row.
+ */
+public class EmsTimeTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
+        runner.addSetupQuery("from deephaven.updateby import ems_time");
+    }
+
+    @Test
+    public void emsTime0Group1Col() {
+        var q = "timed.update_by(ops=ems_time(ts_col='timestamp', time_scale='00:00:02', cols=['X=int5']))";
+        runner.test("EmsTime- No Groups 1 Col", q, "int5", "timestamp");
+    }
+
+    @Test
+    public void emsTime1Group1Col() {
+        var q = "timed.update_by(ops=ems_time(ts_col='timestamp', time_scale='00:00:02', cols=['X=int5']), by=['str100'])";
+        runner.test("EmsTime- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5", "timestamp");
+    }
+
+    @Test
+    public void emsTime2GroupsInt() {
+        var q = "timed.update_by(ops=ems_time(ts_col='timestamp', time_scale='00:00:02', cols=['X=int5']), by=['str100','str150'])";
+        runner.test("EmsTime- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
+                "int5", "timestamp");
+    }
+    
+    @Test
+    public void emsTime2GroupsFloat() {
+        var q = "timed.update_by(ops=ems_time(ts_col='timestamp', time_scale='00:00:02', cols=['X=float5']), by=['str100','str150'])";
+        runner.test("EmsTime- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
+                "float5", "timestamp");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/MixedComboTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/MixedComboTest.java
@@ -13,7 +13,7 @@ public class MixedComboTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         setupStr = """

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTimeTest.java
@@ -13,7 +13,7 @@ public class RollingAvgTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -28,6 +28,8 @@ public class RollingAvgTimeTest {
 
     @Test
     public void rollingAvgTime0Group3Ops() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingAvgTime- 3 Ops No Groups", q, "int5", "timestamp");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingComboTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingComboTest.java
@@ -13,9 +13,8 @@ public class RollingComboTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
-        
         setupStr = """
         from deephaven.updateby import rolling_sum_time, rolling_min_time, rolling_prod_time
         from deephaven.updateby import rolling_avg_tick, rolling_max_tick, rolling_group_tick

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingCountTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingCountTickTest.java
@@ -1,0 +1,65 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a tick-based rolling count. The result table contains
+ * additional columns with windowed rolling count1 for each specified column in the source table.
+ */
+public class RollingCountTickTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_count_tick
+        contains_row = rolling_count_tick(cols=["Contains = int5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_count_tick(cols=["Before = int5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_count_tick(cols=["After = int5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingCountTick0Group3Ops() {
+        runner.setScaleFactors(4, 4);
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingCountTick- 3 Ops No Groups", q, "int5");
+    }
+
+    @Test
+    public void rollingCountTick1Group3Ops() {
+        runner.setScaleFactors(4, 1);
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingCountTick- 3 Ops 1 Group 100 Unique Vals", q, "str100", "int5");
+    }
+
+    @Test
+    public void rollingCountTick2Groups3OpsInt() {
+        runner.setScaleFactors(3, 1);
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingCountTick- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
+                "int5");
+    }
+
+    @Test
+    public void rollingCountTick2Groups3OpsFloat() {
+        runner.setScaleFactors(3, 1);
+        var setup = """
+        contains_row = rolling_count_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_count_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_count_tick(cols=["After = float5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingCountTick- 3 Ops 2 Groups 15K Unique Combos Float", q, "str100", "str150",
+                "float5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingCountTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingCountTimeTest.java
@@ -1,0 +1,62 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a time-based rolling count. The result table contains
+ * additional columns with windowed rolling counts for each specified column in the source table.
+ */
+public class RollingCountTimeTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_count_time
+        contains_row = rolling_count_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_count_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_count_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingCountTime0Group3Ops() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingCountTime- 3 Ops No Groups", q, "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingCountTime1Group3Ops() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingCountTime- 3 Ops 1 Group 100 Unique Vals", q, "str100", "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingCountTime2Groups3OpsInt() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingCountTime- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
+                "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingCountTime2Groups3OpsFloat() {
+        var setup = """
+        contains_row = rolling_count_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_count_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_count_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        """;
+        runner.addSetupQuery(setup);
+
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingCountTime- 3 Ops 2 Groups 15K Unique Combos Float", q, "str100", "str150",
+                "float5", "timestamp");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingGroupTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingGroupTimeTest.java
@@ -13,7 +13,7 @@ public class RollingGroupTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -28,6 +28,8 @@ public class RollingGroupTimeTest {
 
     @Test
     public void rollingGroupTime0Group3Ops() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingGroupTime- 3 Ops No Groups", q, "int5", "timestamp");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTimeTest.java
@@ -13,7 +13,7 @@ public class RollingMaxTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTimeTest.java
@@ -13,7 +13,7 @@ public class RollingMinTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTimeTest.java
@@ -13,7 +13,7 @@ public class RollingProdTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingStdTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingStdTickTest.java
@@ -1,0 +1,65 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a tick-based rolling standard deviation. The result table
+ * contains additional columns with windowed rolling standard deviations for each specified column in the source table.
+ */
+public class RollingStdTickTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_std_tick
+        contains_row = rolling_std_tick(cols=["Contains = int5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_std_tick(cols=["Before = int5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_std_tick(cols=["After = int5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingStdTick0Group3Ops() {
+        runner.setScaleFactors(1, 1);
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingStdTick- 3 Ops No Groups", q, "int5");
+    }
+
+    @Test
+    public void rollingStdTick1Group3Ops() {
+        runner.setScaleFactors(2, 1);
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingStdTick- 3 Ops 1 Group 100 Unique Vals", q, "str100", "int5");
+    }
+
+    @Test
+    public void rollingStdTime2Groups3OpsInt() {
+        runner.setScaleFactors(2, 1);
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingStdTick- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
+                "int5");
+    }
+
+    @Test
+    public void rollingStdTick2Groups3OpsFloat() {
+        runner.setScaleFactors(2, 1);
+        var setup = """
+        contains_row = rolling_std_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_std_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_std_tick(cols=["After = float5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingStdTick- 3 Ops 2 Groups 15K Unique Combos Float", q, "str100", "str150",
+                "float5");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingStdTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingStdTimeTest.java
@@ -1,0 +1,62 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a time-based rolling standard deviation. The result table
+ * contains additional columns with windowed rolling standard deviations for each specified column in the source table.
+ */
+public class RollingStdTimeTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_std_time
+        contains_row = rolling_std_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_std_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_std_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingStdTime0Group3Ops() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingStdTime- 3 Ops No Groups", q, "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingStdTime1Group3Ops() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingStdTime- 3 Ops 1 Group 100 Unique Vals", q, "str100", "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingStdTime2Groups3OpsInt() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingStdTime- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
+                "int5", "timestamp");
+    }
+
+    @Test
+    public void rollingStdTime2Groups3OpsFloat() {
+        var setup = """
+        contains_row = rolling_std_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_std_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_std_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        """;
+        runner.addSetupQuery(setup);
+
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingStdTime- 3 Ops 2 Groups 15K Unique Combos Float", q, "str100", "str150",
+                "float5", "timestamp");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingStdTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingStdTimeTest.java
@@ -13,7 +13,7 @@ public class RollingStdTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -28,6 +28,8 @@ public class RollingStdTimeTest {
 
     @Test
     public void rollingStdTime0Group3Ops() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingStdTime- 3 Ops No Groups", q, "int5", "timestamp");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTimeTest.java
@@ -13,7 +13,7 @@ public class RollingSumTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -28,6 +28,8 @@ public class RollingSumTimeTest {
 
     @Test
     public void rollingSumTime0Group3Ops() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingSumTime- 3 Ops No Groups", q, "int5", "timestamp");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTickTest.java
@@ -1,0 +1,64 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a tick-based rolling weighted-average. The result table
+ * contains additional columns with windowed rolling weighted-averages for each specified column in the source table.
+ */
+public class RollingWAvgTickTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_wavg_tick
+        contains_row = rolling_wavg_tick('int10', cols=["Contains = int5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_wavg_tick('int10', cols=["Before = int5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_wavg_tick('int10', cols=["After = int5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingWAvgTick0Group3Ops() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingWAvgTick- 3 Ops No Groups", q, "int5", "int10");
+    }
+
+    @Test
+    public void rollingWAvgTick1Group3Ops() {
+        runner.setScaleFactors(2, 1);
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingWAvgTick- 3 Ops 1 Group 100 Unique Vals", q, "str100", "int5", "int10");
+    }
+
+    @Test
+    public void rollingWAvgTime2Groups3OpsInt() {
+        runner.setScaleFactors(2, 1);
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingWAvgTick- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
+                "int5", "int10");
+    }
+
+    @Test
+    public void rollingWAvgTick2Groups3OpsFloat() {
+        runner.setScaleFactors(2, 1);
+        var setup = """
+        contains_row = rolling_wavg_tick(weight_col='int10', cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_wavg_tick(weight_col='int10', cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_wavg_tick(weight_col='int10', cols=["After = float5"], rev_ticks=-1, fwd_ticks=3)
+        """;
+        runner.addSetupQuery(setup);
+
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingWAvgTick- 3 Ops 2 Groups 15K Unique Combos Float", q, "str100", "str150",
+                "float5", "int10");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTimeTest.java
@@ -1,0 +1,62 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.updateby;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the updateBy table operation. Defines a time-based rolling weighted-average. The result table
+ * contains additional columns with windowed rolling weighted-averages for each specified column in the source table.
+ */
+public class RollingWAvgTimeTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    public void setup() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
+
+        var setup = """
+        from deephaven.updateby import rolling_wavg_time
+        contains_row = rolling_wavg_time("timestamp", 'int10', cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_wavg_time("timestamp", 'int10', cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_wavg_time("timestamp", 'int10', cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        
+        """;
+        runner.addSetupQuery(setup);
+    }
+
+    @Test
+    public void rollingWAvgTime0Group3Ops() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
+        runner.test("RollingWAvgTime- 3 Ops No Groups", q, "int5", "timestamp", "int10");
+    }
+
+    @Test
+    public void rollingWAvgTime1Group3Ops() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
+        runner.test("RollingWAvgTime- 3 Ops 1 Group 100 Unique Vals", q, "str100", "int5", "timestamp", "int10");
+    }
+
+    @Test
+    public void rollingWAvgTime2Groups3OpsInt() {
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingWAvgTime- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
+                "int5", "timestamp", "int10");
+    }
+
+    @Test
+    public void rollingWAvgTime2Groups3OpsFloat() {
+        var setup = """
+        contains_row = rolling_wavg_time("timestamp", 'int10', cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
+        before_row = rolling_wavg_time("timestamp", 'int10', cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
+        after_row = rolling_wavg_time("timestamp", 'int10', cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        """;
+        runner.addSetupQuery(setup);
+
+        var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
+        runner.test("RollingWAvgTime- 3 Ops 2 Groups 15K Unique Combos Float", q, "str100", "str150",
+                "float5", "timestamp", "int10");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTimeTest.java
@@ -13,7 +13,7 @@ public class RollingWAvgTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -28,6 +28,8 @@ public class RollingWAvgTimeTest {
 
     @Test
     public void rollingWAvgTime0Group3Ops() {
+        runner.setRowFactor(6);
+        runner.tables("timed");
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingWAvgTime- 3 Ops No Groups", q, "int5", "timestamp", "int10");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereNotInTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereNotInTest.java
@@ -28,7 +28,7 @@ public class WhereNotInTest {
 
     @Test
     public void whereNotIn1Filter() {
-        runner.setScaleFactors(100, 10);
+        runner.setScaleFactors(80, 10);
         var q = "source.where_not_in(where_filter, cols=['str250 = sPrefix'])";
         runner.test("WhereNotIn- 1 Filter Col", q, "str250", "int250");
     }


### PR DESCRIPTION
Added more updateby tests. Added scaling where helpful.

- RollingWAvg
- Exponential Moving Sum
- Exponential Min/Max
- RollingCount
- RollingStd

Diff was not done because the Benchmark framework doesn't properly support NULLs.  This will be done in a future story. (https://github.com/deephaven/benchmark/issues/40)

Attached is a run of the updateby package on the Benchmark server against the latest edge build (shows up as 0.25.0)

[2022-05-15_bench_results_updateby.csv](https://github.com/deephaven/benchmark/files/11482515/2022-05-15_bench_results_updateby.csv)
