### PR TITLE
Used >= or <= instead of = for last aj/raj join column

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/internal/generator/DataTypesTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/generator/DataTypesTest.java
@@ -30,7 +30,7 @@ public class DataTypesTest {
         """;
 
         api.query(query).fetchAfter("meta", table -> {
-            assertEquals("io.deephaven.time.DateTime", table.getValue(0, "DataType").toString(), "Wrong data type");
+            assertEquals("java.time.Instant", table.getValue(0, "DataType").toString(), "Wrong data type");
             assertEquals("long", table.getValue(1, "DataType").toString(), "Wrong data type");
             assertEquals("int", table.getValue(2, "DataType").toString(), "Wrong data type");
             assertEquals("double", table.getValue(3, "DataType").toString(), "Wrong data type");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/join/AsOfJoinTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/join/AsOfJoinTest.java
@@ -20,19 +20,19 @@ public class AsOfJoinTest {
 
     @Test
     public void asOfJoinOn1Col1Match() {
-        var q = "source.aj(right, on=['str1M=r_str1M'])";
+        var q = "source.aj(right, on=['str1M >= r_str1M'])";
         runner.test("AsOfJoin- Join On 1 Col 1 Match", q, "str1M", "int250");
     }
 
     @Test
     public void asOfJoinOn2Cols1Match() {
-        var q = "source.aj(right, on=['str1M=r_str1M', 'int1M=r_int1M'])";
+        var q = "source.aj(right, on=['str1M = r_str1M', 'int1M >= r_int1M'])";
         runner.test("AsOfJoin- Join On 2 Cols 1 Match", q, "str1M", "int1M", "int250");
     }
 
     @Test
     public void asOfJoinOn2ColsManyMatch() {
-        var q = "source.aj(right, on=['str640=r_str640', 'str250=r_str250'])";
+        var q = "source.aj(right, on=['str640 = r_str640', 'str250 >= r_str250'])";
         runner.test("AsOfJoin- Join On 2 Cols Many Match", q, "str250", "str640", "int250");
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/join/ReverseAsOfJoinTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/join/ReverseAsOfJoinTest.java
@@ -20,21 +20,20 @@ public class ReverseAsOfJoinTest {
 
     @Test
     public void reverseAsOfJoinOn1Col1Match() {
-        var q = "source.raj(right, on=['str1M=r_str1M'])";
-        runner.test("ReverseAsOfJoin- Join On 1 Col 1 Match",  q, "str1M", "int250");
+        var q = "source.raj(right, on=['str1M <= r_str1M'])";
+        runner.test("ReverseAsOfJoin- Join On 1 Col 1 Match", q, "str1M", "int250");
     }
 
     @Test
     public void reverseAsOfJoinOn2Cols1Match() {
-        var q = "source.raj(right, on=['str1M=r_str1M', 'int1M=r_int1M'])";
+        var q = "source.raj(right, on=['str1M = r_str1M', 'int1M <= r_int1M'])";
         runner.test("ReverseAsOfJoin- Join On 2 Cols 1 Match", q, "str1M", "int1M", "int250");
     }
 
     @Test
     public void reverseAsOfJoinOn2ColsManyMatch() {
-        var q = "source.raj(right, on=['str640=r_str640', 'str250=r_str250'])";
-        runner.test("ReverseAsOfJoin- Join On 2 Cols Many Match", q, "str250", "str640",
-                "int250");
+        var q = "source.raj(right, on=['str640 = r_str640', 'str250 <= r_str250'])";
+        runner.test("ReverseAsOfJoin- Join On 2 Cols Many Match", q, "str250", "str640", "int250");
     }
 
 }


### PR DESCRIPTION
- Updated AsOfJoin and ReverseAsOfJoin to use >= and <= in the last join column, since = is now illegal
- Verified that the resulting table in each case has the same result row count as before
- Updated Data Types integration tests to expect Instant instead of DateTime