### PR TITLE
Fixed UpdateBy Time Operations for DHC Breaking Changes

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumComboTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumComboTest.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
+import java.time.Duration;
 import org.junit.jupiter.api.*;
 import io.deephaven.benchmark.tests.standard.StandardTestRunner;
 
@@ -21,7 +22,7 @@ public class CumComboTest {
         from deephaven.updateby import cum_max, cum_min, cum_sum, cum_prod
         
         ema_tick_op = ema_tick(decay_ticks=100,cols=['U=${calc.col}'])
-        ema_time_op = ema_time(ts_col='timestamp', decay_time='00:00:02', cols=['V=${calc.col}'])
+        ema_time_op = ema_time(ts_col='timestamp', decay_time='PT2S', cols=['V=${calc.col}'])
         max_op = cum_max(cols=['W=${calc.col}'])
         min_op = cum_min(cols=['X=${calc.col}'])
         sum_op = cum_sum(cols=['Y=${calc.col}'])

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTimeTest.java
@@ -20,26 +20,26 @@ public class EmMaxTimeTest {
 
     @Test
     public void emMaxTime0Group1Col() {
-        var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=int5']))";
+        var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']))";
         runner.test("EmMaxTime- No Groups 1 Col", q, "int5", "timestamp");
     }
 
     @Test
     public void emMaxTime1Group1Col() {
-        var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=int5']), by=['str100'])";
+        var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100'])";
         runner.test("EmMaxTime- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void emMaxTime2GroupsInt() {
-        var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=int5']), by=['str100','str150'])";
+        var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100','str150'])";
         runner.test("EmMaxTime- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5", "timestamp");
     }
 
     @Test
     public void emMaxTime2GroupsFloat() {
-        var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=float5']), by=['str100','str150'])";
+        var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', decay_time='PT2S', cols=['X=float5']), by=['str100','str150'])";
         runner.test("EmMaxTime- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
                 "float5", "timestamp");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTimeTest.java
@@ -20,26 +20,26 @@ public class EmMinTimeTest {
 
     @Test
     public void emMinTime0Group1Col() {
-        var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=int5']))";
+        var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']))";
         runner.test("EmMinTime- No Groups 1 Col", q, "int5", "timestamp");
     }
 
     @Test
     public void emMinTime1Group1Col() {
-        var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=int5']), by=['str100'])";
+        var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100'])";
         runner.test("EmMinTime- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void emMinTime2GroupsInt() {
-        var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=int5']), by=['str100','str150'])";
+        var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100','str150'])";
         runner.test("EmMinTime- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5", "timestamp");
     }
 
     @Test
     public void emMinTime2GroupsFloat() {
-        var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=float5']), by=['str100','str150'])";
+        var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', decay_time='PT2S', cols=['X=float5']), by=['str100','str150'])";
         runner.test("EmMinTime- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
                 "float5", "timestamp");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTimeTest.java
@@ -20,26 +20,26 @@ public class EmaTimeTest {
 
     @Test
     public void emaTime0Group1Col() {
-        var q = "timed.update_by(ops=ema_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=int5']))";
+        var q = "timed.update_by(ops=ema_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']))";
         runner.test("EmaTime- No Groups 1 Col", q, "int5", "timestamp");
     }
 
     @Test
     public void emaTime1Group1Col() {
-        var q = "timed.update_by(ops=ema_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=int5']), by=['str100'])";
+        var q = "timed.update_by(ops=ema_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100'])";
         runner.test("EmaTime- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void emaTime2GroupsInt() {
-        var q = "timed.update_by(ops=ema_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=int5']), by=['str100','str150'])";
+        var q = "timed.update_by(ops=ema_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100','str150'])";
         runner.test("EmaTime- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5", "timestamp");
     }
     
     @Test
     public void emaTime2GroupsFloat() {
-        var q = "timed.update_by(ops=ema_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=float5']), by=['str100','str150'])";
+        var q = "timed.update_by(ops=ema_time(ts_col='timestamp', decay_time='PT2S', cols=['X=float5']), by=['str100','str150'])";
         runner.test("EmaTime- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
                 "float5", "timestamp");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTimeTest.java
@@ -20,26 +20,26 @@ public class EmsTimeTest {
 
     @Test
     public void emsTime0Group1Col() {
-        var q = "timed.update_by(ops=ems_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=int5']))";
+        var q = "timed.update_by(ops=ems_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']))";
         runner.test("EmsTime- No Groups 1 Col", q, "int5", "timestamp");
     }
 
     @Test
     public void emsTime1Group1Col() {
-        var q = "timed.update_by(ops=ems_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=int5']), by=['str100'])";
+        var q = "timed.update_by(ops=ems_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100'])";
         runner.test("EmsTime- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void emsTime2GroupsInt() {
-        var q = "timed.update_by(ops=ems_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=int5']), by=['str100','str150'])";
+        var q = "timed.update_by(ops=ems_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100','str150'])";
         runner.test("EmsTime- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5", "timestamp");
     }
     
     @Test
     public void emsTime2GroupsFloat() {
-        var q = "timed.update_by(ops=ems_time(ts_col='timestamp', decay_time='00:00:02', cols=['X=float5']), by=['str100','str150'])";
+        var q = "timed.update_by(ops=ems_time(ts_col='timestamp', decay_time='PT2S', cols=['X=float5']), by=['str100','str150'])";
         runner.test("EmsTime- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
                 "float5", "timestamp");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/MixedComboTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/MixedComboTest.java
@@ -20,9 +20,9 @@ public class MixedComboTest {
         from deephaven.updateby import rolling_avg_time, rolling_max_tick, rolling_prod_time
         from deephaven.updateby import ema_tick, cum_min, cum_sum
          
-        avg_contains = rolling_avg_time(ts_col="timestamp", cols=["U=${calc.col}"], rev_time="00:00:01", fwd_time="00:00:01")
+        avg_contains = rolling_avg_time(ts_col="timestamp", cols=["U=${calc.col}"], rev_time="PT1S", fwd_time="PT1S")
         max_before = rolling_max_tick(cols=["V = ${calc.col}"], rev_ticks=3, fwd_ticks=-1)
-        prod_after = rolling_prod_time(ts_col="timestamp", cols=["W=${calc.col}"], rev_time="-00:00:01", fwd_time=int(3e9))
+        prod_after = rolling_prod_time(ts_col="timestamp", cols=["W=${calc.col}"], rev_time="-PT1S", fwd_time=int(3e9))
         
         ema_tick_op = ema_tick(decay_ticks=100,cols=['X=${calc.col}'])
         min_op = cum_min(cols=['Y=${calc.col}'])

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTimeTest.java
@@ -18,9 +18,9 @@ public class RollingAvgTimeTest {
 
         var setup = """
         from deephaven.updateby import rolling_avg_time
-        contains_row = rolling_avg_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_avg_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_avg_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_avg_time(ts_col="timestamp", cols=["X=int5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_avg_time(ts_col="timestamp", cols=["Y=int5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_avg_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-PT1S", fwd_time=int(3e9))
         
         """;
         runner.addSetupQuery(setup);
@@ -50,9 +50,9 @@ public class RollingAvgTimeTest {
     @Test
     public void rollingAvgTime2Groups3OpsFloat() {
         var setup = """
-        contains_row = rolling_avg_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_avg_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_avg_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_avg_time(ts_col="timestamp", cols=["X=float5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_avg_time(ts_col="timestamp", cols=["Y=float5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_avg_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-PT1S", fwd_time=int(3e9))
         """;
         runner.addSetupQuery(setup);
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingComboTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingComboTest.java
@@ -19,9 +19,9 @@ public class RollingComboTest {
         from deephaven.updateby import rolling_sum_time, rolling_min_time, rolling_prod_time
         from deephaven.updateby import rolling_avg_tick, rolling_max_tick, rolling_group_tick
          
-        sum_contains = rolling_sum_time(ts_col="timestamp", cols=["U=${calc.col}"], rev_time="00:00:01", fwd_time="00:00:01")
-        min_before = rolling_min_time(ts_col="timestamp", cols=["V=${calc.col}"], rev_time="00:00:03", fwd_time=int(-1e9))
-        prod_after = rolling_prod_time(ts_col="timestamp", cols=["W=${calc.col}"], rev_time="-00:00:01", fwd_time=int(3e9))
+        sum_contains = rolling_sum_time(ts_col="timestamp", cols=["U=${calc.col}"], rev_time="PT1S", fwd_time="PT1S")
+        min_before = rolling_min_time(ts_col="timestamp", cols=["V=${calc.col}"], rev_time="PT3S", fwd_time=int(-1e9))
+        prod_after = rolling_prod_time(ts_col="timestamp", cols=["W=${calc.col}"], rev_time="-PT1S", fwd_time=int(3e9))
         
         avg_contains = rolling_avg_tick(cols=["X = ${calc.col}"], rev_ticks=1, fwd_ticks=1)
         max_before = rolling_max_tick(cols=["Y = ${calc.col}"], rev_ticks=3, fwd_ticks=-1)

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingCountTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingCountTimeTest.java
@@ -18,9 +18,9 @@ public class RollingCountTimeTest {
 
         var setup = """
         from deephaven.updateby import rolling_count_time
-        contains_row = rolling_count_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_count_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_count_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_count_time(ts_col="timestamp", cols=["X=int5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_count_time(ts_col="timestamp", cols=["Y=int5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_count_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-PT1S", fwd_time=int(3e9))
         
         """;
         runner.addSetupQuery(setup);
@@ -48,9 +48,9 @@ public class RollingCountTimeTest {
     @Test
     public void rollingCountTime2Groups3OpsFloat() {
         var setup = """
-        contains_row = rolling_count_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_count_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_count_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_count_time(ts_col="timestamp", cols=["X=float5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_count_time(ts_col="timestamp", cols=["Y=float5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_count_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-PT1S", fwd_time=int(3e9))
         """;
         runner.addSetupQuery(setup);
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingGroupTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingGroupTimeTest.java
@@ -18,9 +18,9 @@ public class RollingGroupTimeTest {
 
         var setup = """
         from deephaven.updateby import rolling_group_time
-        contains_row = rolling_group_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_group_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_group_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_group_time(ts_col="timestamp", cols=["X=int5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_group_time(ts_col="timestamp", cols=["Y=int5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_group_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-PT1S", fwd_time=int(3e9))
         
         """;
         runner.addSetupQuery(setup);
@@ -50,9 +50,9 @@ public class RollingGroupTimeTest {
     @Test
     public void rollingGroupTime2Groups3OpsFloat() {
         var setup = """
-        contains_row = rolling_group_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_group_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_group_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_group_time(ts_col="timestamp", cols=["X=float5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_group_time(ts_col="timestamp", cols=["Y=float5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_group_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-PT1S", fwd_time=int(3e9))
         """;
         runner.addSetupQuery(setup);
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTimeTest.java
@@ -18,9 +18,9 @@ public class RollingMaxTimeTest {
 
         var setup = """
         from deephaven.updateby import rolling_max_time
-        contains_row = rolling_max_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_max_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_max_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_max_time(ts_col="timestamp", cols=["X=int5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_max_time(ts_col="timestamp", cols=["Y=int5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_max_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-PT1S", fwd_time=int(3e9))
         
         """;
         runner.addSetupQuery(setup);
@@ -48,9 +48,9 @@ public class RollingMaxTimeTest {
     @Test
     public void rollingMaxTime2Groups3OpsFloat() {
         var setup = """
-        contains_row = rolling_max_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_max_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_max_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_max_time(ts_col="timestamp", cols=["X=float5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_max_time(ts_col="timestamp", cols=["Y=float5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_max_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-PT1S", fwd_time=int(3e9))
         """;
         runner.addSetupQuery(setup);
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTimeTest.java
@@ -18,9 +18,9 @@ public class RollingMinTimeTest {
 
         var setup = """
         from deephaven.updateby import rolling_min_time
-        contains_row = rolling_min_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_min_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_min_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_min_time(ts_col="timestamp", cols=["X=int5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_min_time(ts_col="timestamp", cols=["Y=int5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_min_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-PT1S", fwd_time=int(3e9))
         
         """;
         runner.addSetupQuery(setup);
@@ -48,9 +48,9 @@ public class RollingMinTimeTest {
     @Test
     public void rollingMinTime2Groups3OpsFloat() {
         var setup = """
-        contains_row = rolling_min_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_min_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_min_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_min_time(ts_col="timestamp", cols=["X=float5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_min_time(ts_col="timestamp", cols=["Y=float5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_min_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-PT1S", fwd_time=int(3e9))
         """;
         runner.addSetupQuery(setup);
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTimeTest.java
@@ -18,9 +18,9 @@ public class RollingProdTimeTest {
 
         var setup = """
         from deephaven.updateby import rolling_prod_time
-        contains_row = rolling_prod_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_prod_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_prod_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_prod_time(ts_col="timestamp", cols=["X=int5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_prod_time(ts_col="timestamp", cols=["Y=int5"], rev_time="PT1S", fwd_time=int(-1e9))
+        after_row = rolling_prod_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-PT1S", fwd_time=int(3e9))
         
         """;
         runner.addSetupQuery(setup);
@@ -48,9 +48,9 @@ public class RollingProdTimeTest {
     @Test
     public void rollingProdTime2Groups3OpsFloat() {
         var setup = """
-        contains_row = rolling_prod_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_prod_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_prod_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_prod_time(ts_col="timestamp", cols=["X=float5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_prod_time(ts_col="timestamp", cols=["Y=float5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_prod_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-PT1S", fwd_time=int(3e9))
         """;
         runner.addSetupQuery(setup);
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingStdTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingStdTimeTest.java
@@ -18,9 +18,9 @@ public class RollingStdTimeTest {
 
         var setup = """
         from deephaven.updateby import rolling_std_time
-        contains_row = rolling_std_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_std_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_std_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_std_time(ts_col="timestamp", cols=["X=int5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_std_time(ts_col="timestamp", cols=["Y=int5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_std_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-PT1S", fwd_time=int(3e9))
         
         """;
         runner.addSetupQuery(setup);
@@ -50,9 +50,9 @@ public class RollingStdTimeTest {
     @Test
     public void rollingStdTime2Groups3OpsFloat() {
         var setup = """
-        contains_row = rolling_std_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_std_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_std_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_std_time(ts_col="timestamp", cols=["X=float5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_std_time(ts_col="timestamp", cols=["Y=float5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_std_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-PT1S", fwd_time=int(3e9))
         """;
         runner.addSetupQuery(setup);
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTimeTest.java
@@ -18,9 +18,9 @@ public class RollingSumTimeTest {
 
         var setup = """
         from deephaven.updateby import rolling_sum_time
-        contains_row = rolling_sum_time(ts_col="timestamp", cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_sum_time(ts_col="timestamp", cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_sum_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_sum_time(ts_col="timestamp", cols=["X=int5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_sum_time(ts_col="timestamp", cols=["Y=int5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_sum_time(ts_col="timestamp", cols=["Z=int5"], rev_time="-PT1S", fwd_time=int(3e9))
         
         """;
         runner.addSetupQuery(setup);
@@ -50,9 +50,9 @@ public class RollingSumTimeTest {
     @Test
     public void rollingSumTime2Groups3OpsFloat() {
         var setup = """
-        contains_row = rolling_sum_time(ts_col="timestamp", cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_sum_time(ts_col="timestamp", cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_sum_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_sum_time(ts_col="timestamp", cols=["X=float5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_sum_time(ts_col="timestamp", cols=["Y=float5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_sum_time(ts_col="timestamp", cols=["Z=float5"], rev_time="-PT1S", fwd_time=int(3e9))
         """;
         runner.addSetupQuery(setup);
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTimeTest.java
@@ -18,9 +18,9 @@ public class RollingWAvgTimeTest {
 
         var setup = """
         from deephaven.updateby import rolling_wavg_time
-        contains_row = rolling_wavg_time("timestamp", 'int10', cols=["X=int5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_wavg_time("timestamp", 'int10', cols=["Y=int5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_wavg_time("timestamp", 'int10', cols=["Z=int5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_wavg_time("timestamp", 'int10', cols=["X=int5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_wavg_time("timestamp", 'int10', cols=["Y=int5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_wavg_time("timestamp", 'int10', cols=["Z=int5"], rev_time="-PT1S", fwd_time=int(3e9))
         
         """;
         runner.addSetupQuery(setup);
@@ -50,9 +50,9 @@ public class RollingWAvgTimeTest {
     @Test
     public void rollingWAvgTime2Groups3OpsFloat() {
         var setup = """
-        contains_row = rolling_wavg_time("timestamp", 'int10', cols=["X=float5"], rev_time="00:00:01", fwd_time="00:00:01")
-        before_row = rolling_wavg_time("timestamp", 'int10', cols=["Y=float5"], rev_time="00:00:03", fwd_time=int(-1e9))
-        after_row = rolling_wavg_time("timestamp", 'int10', cols=["Z=float5"], rev_time="-00:00:01", fwd_time=int(3e9))
+        contains_row = rolling_wavg_time("timestamp", 'int10', cols=["X=float5"], rev_time="PT1S", fwd_time="PT1S")
+        before_row = rolling_wavg_time("timestamp", 'int10', cols=["Y=float5"], rev_time="PT3S", fwd_time=int(-1e9))
+        after_row = rolling_wavg_time("timestamp", 'int10', cols=["Z=float5"], rev_time="-PT1S", fwd_time=int(3e9))
         """;
         runner.addSetupQuery(setup);
 


### PR DESCRIPTION
Changed decay_time, rev_time, fwd_time to use Duration syntax to comport with the changes made to syntax in DHC.