### PR TITLE
Added kafka tests for Avro and JSON

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaBlinkHeapTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaBlinkHeapTest.java
@@ -1,0 +1,53 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.kafka;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Run CountBy operation on Kafka blink data at different heap settings. Some tests have a heap that is smaller than the
+ * incoming data, and some have heaps that are larger.
+ */
+public class KafkaBlinkHeapTest {
+    final KafkaTestRunner runner = new KafkaTestRunner(this);
+    final long rowCount = runner.api.propertyAsIntegral("scale.row.count", "100000") * 2;
+    final int colCount = 20;
+
+    @Test
+    public void CountBy1gHeapFromKafkaAvroBlink() {
+        runner.api.setName("CountBy- 20 Cols 1g Heap Avro Blink");
+        runner.restartWithHeap(1);
+        runner.table(rowCount / 2, colCount, "long", "avro");
+        runner.runTest("consumer_tbl.count_by('count')", "blink");
+    }
+
+    @Test
+    public void CountBy1gHeapFromKafkaJsonBlink() {
+        runner.api.setName("CountBy- 20 Cols 1g Heap JSON Blink");
+        runner.restartWithHeap(1);
+        runner.table(rowCount / 4, colCount, "long", "json");
+        runner.runTest("consumer_tbl.count_by('count')", "blink");
+    }
+
+    @Test
+    public void CountBy10gHeapFromKafkaAvroBlink() {
+        runner.api.setName("CountBy- 20 Cols 10g Heap Avro Blink");
+        runner.restartWithHeap(10);
+        runner.table(rowCount / 2, colCount, "long", "avro");
+        runner.runTest("consumer_tbl.count_by('count')", "blink");
+    }
+
+    @Test
+    public void CountBy10gHeapFromKafkaJsonBlink() {
+        runner.api.setName("CountBy- 20 Cols 10g Heap JSON Blink");
+        runner.restartWithHeap(10);
+        runner.table(rowCount / 4, colCount, "long", "json");
+        runner.runTest("consumer_tbl.count_by('count')", "blink");
+    }
+
+    @AfterEach
+    public void teardown() {
+        runner.api.close();
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaBlinkWidthTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaBlinkWidthTest.java
@@ -1,0 +1,67 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.kafka;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Run a CountBy operation on Kafka blink data at different column widths
+ */
+public class KafkaBlinkWidthTest {
+    final KafkaTestRunner runner = new KafkaTestRunner(this);
+    final long rowCount = runner.api.propertyAsIntegral("scale.row.count", "100000");
+
+    @Test
+    public void CountBy10ColsFromKafkaAvroBlink() {
+        runner.api.setName("CountBy- 10 Cols Wide Avro Blink");
+        runner.restartWithHeap(10);
+        runner.table(rowCount, 10, "long", "avro");
+        runner.runTest("consumer_tbl.count_by('count')", "blink");
+    }
+
+    @Test
+    public void CountBy10ColsFromKafkaJsonBlink() {
+        runner.api.setName("CountBy- 10 Cols Wide JSON Blink");
+        runner.restartWithHeap(10);
+        runner.table(rowCount, 10, "long", "json");
+        runner.runTest("consumer_tbl.count_by('count')", "blink");
+    }
+    
+    @Test
+    public void CountBy100ColsFromKafkaAvroBlink() {
+        runner.api.setName("CountBy- 100 Cols Wide Avro Blink");
+        runner.restartWithHeap(10);
+        runner.table(rowCount / 3, 100, "long", "avro");
+        runner.runTest("consumer_tbl.count_by('count')", "blink");
+    }
+
+    @Test
+    public void CountBy100ColsFromKafkaJsonBlink() {
+        runner.api.setName("CountBy- 100 Cols Wide JSON Blink");
+        runner.restartWithHeap(10);
+        runner.table(rowCount / 10, 100, "long", "json");
+        runner.runTest("consumer_tbl.count_by('count')", "blink");
+    }
+    
+    @Test
+    public void CountBy1000ColsFromKafkaAvroBlink() {
+        runner.api.setName("CountBy- 1000 Cols Wide Avro Blink");
+        runner.restartWithHeap(10);
+        runner.table(rowCount / 25, 1000, "long", "avro");
+        runner.runTest("consumer_tbl.count_by('count')", "blink");
+    }
+
+    @Test
+    public void CountBy1000ColsgFromKafkaJsonBlink() {
+        runner.api.setName("CountBy- 1000 Cols Wide JSON Blink");
+        runner.restartWithHeap(10);
+        runner.table(rowCount / 100, 1000, "long", "json");
+        runner.runTest("consumer_tbl.count_by('count')", "blink");
+    }
+
+    @AfterEach
+    public void teardown() {
+        runner.api.close();
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaDataTypeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaDataTypeTest.java
@@ -1,0 +1,68 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.kafka;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Run a CountBy operation on a Kafka append consumer to compare different data types read from Kafka topics
+ */
+public class KafkaDataTypeTest {
+    final KafkaTestRunner runner = new KafkaTestRunner(this);
+    final long rowCount = runner.api.propertyAsIntegral("scale.row.count", "100000");
+    final int colCount = 20;
+
+    @Test
+    public void NoOp20LongColsFromKafkaAvroAppend() {
+        runner.api.setName("NoOp- 20 Long Cols Avro Append");
+        runner.restartWithHeap(10);
+        runner.table(rowCount, colCount, "long", "avro");
+        runner.runTest("None", "append");
+    }
+
+    @Test
+    public void NoOp20LongColsFromKafkaJsonAppend() {
+        runner.api.setName("NoOp- 20 Long Cols JSON Append");
+        runner.restartWithHeap(10);
+        runner.table(rowCount / 2, colCount, "long", "json");
+        runner.runTest("None", "append");
+    }
+    
+    @Test
+    public void NoOp20DoubleColsFromKafkaAvroAppend() {
+        runner.api.setName("NoOp- 20 Double Cols Avro Append");
+        runner.restartWithHeap(10);
+        runner.table(rowCount, colCount, "double", "avro");
+        runner.runTest("None", "append");
+    }
+
+    @Test
+    public void NoOpDoubleColsFromKafkaJsonAppend() {
+        runner.api.setName("NoOp- 20 Double Cols JSON Append");
+        runner.restartWithHeap(10);
+        runner.table(rowCount / 4, colCount, "double", "json");
+        runner.runTest("None", "append");
+    }
+    
+    @Test
+    public void NoOp20DateTimeColsFromKafkaAvroAppend() {
+        runner.api.setName("NoOp- 20 DateTime Cols Avro Append");
+        runner.restartWithHeap(10);
+        runner.table(rowCount, colCount, "timestamp-millis", "avro");
+        runner.runTest("None", "append");
+    }
+
+    @Test
+    public void NoOp20DateTimeColsFromKafkaJsonAppend() {
+        runner.api.setName("NoOp- 20 DateTime Cols JSON Append");
+        runner.restartWithHeap(10);
+        runner.table(rowCount / 2, colCount, "timestamp-millis", "json");
+        runner.runTest("None", "append");
+    }
+
+    @AfterEach
+    public void teardown() {
+        runner.api.close();
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaTestRunner.java
@@ -1,0 +1,216 @@
+/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import io.deephaven.benchmark.api.Bench;
+import io.deephaven.benchmark.metric.Metrics;
+import io.deephaven.benchmark.util.Exec;
+import io.deephaven.benchmark.util.Filer;
+import io.deephaven.benchmark.util.Timer;
+
+/**
+ * Used exclusively as a Bench API wrapper to run the Kafka tests. Provides generation of test data through Kafka,
+ * running tests for Kafka consumer according to column data types, JSON/Avro, wide/narrow tables, and append/blink
+ * table types. Results are checked to ensure the correct number of rows has been processed.
+ */
+class KafkaTestRunner {
+    final Object testInst;
+    final Bench api;
+    private long rowCount;
+    private int colCount;
+    private String colType;
+    private String generatorType;
+
+    /**
+     * Initialize the test runner and the Bench API
+     * 
+     * @param testInst the test instance used by the Bench API
+     */
+    KafkaTestRunner(Object testInst) {
+        this.testInst = testInst;
+        this.api = Bench.create(testInst);
+    }
+
+    /**
+     * If a {@code docker.compose.file} is specified in supplied runtime properties, restart the corresponding docker
+     * images with Deephaven max heap set to the given gigabytes.
+     * 
+     * @param deephavenHeapGigs the number of gigabytes to use for Deephave max heap
+     */
+    void restartWithHeap(int deephavenHeapGigs) {
+        restartDocker(api, deephavenHeapGigs);
+    }
+
+    /**
+     * Generate the consumer table to be used for the test.
+     * 
+     * @param rowCount the number of rows to generate
+     * @param colCount the number of columns to generate for each row
+     * @param colType the type of column to generate and consume
+     * @param generatorType the format in which to generate the rows (e.g. avro | json)
+     */
+    void table(long rowCount, int colCount, String colType, String generatorType) {
+        this.rowCount = rowCount;
+        this.colCount = colCount;
+        this.colType = colType;
+        this.generatorType = generatorType;
+
+        var table = api.table("consumer_tbl").fixed();
+        table.add("count", "long", "[1-" + rowCount + "]");
+        for (int i = 1; i < colCount; i++) {
+            table.add("col" + (i + 1), colType, "[1-1000]");
+        }
+        if (generatorType.equals("json")) {
+            table.withRowCount(rowCount).generateJson();
+        } else if (generatorType.equals("avro")) {
+            table.withRowCount(rowCount).generateAvro();
+        } else {
+            throw new RuntimeException("Bad generator type: " + generatorType);
+        }
+        api.awaitCompletion();
+    }
+
+    /**
+     * Run the test and measure the rate of Kafka consumption. Note: Mixing 'None' operation with 'blink' table type is
+     * undefined.
+     * 
+     * @param operation a Deephave operation or 'None'
+     * @param tableType the Kafka consumer {@code TableType} (e.g. append | blink)
+     */
+    void runTest(String operation, String tableType) {
+        var query = """
+        import time
+        from deephaven import new_table, garbage_collect
+        from deephaven.column import long_col, double_col
+        from deephaven.table import Table
+        from deephaven.update_graph import exclusive_lock
+        from deephaven import kafka_consumer as kc
+        from deephaven.stream.kafka.consumer import TableType, KeyValueSpec
+        import deephaven.dtypes as dht
+        
+        kc_spec = ${kafkaConsumerSpec}
+        
+        bench_api_metrics_snapshot()
+        begin_time = time.perf_counter_ns()
+        
+        consumer_tbl = kc.consume({ 'bootstrap.servers' : '${kafka.consumer.addr}' ${schemaRegistryURL} },
+            'consumer_tbl',
+            offsets=kc.ALL_PARTITIONS_SEEK_TO_BEGINNING,
+            key_spec=KeyValueSpec.IGNORE,
+            value_spec=kc_spec,
+            table_type=TableType.${tableType}())
+        
+        result = ${operation}
+        ${awaitTableLoad}
+        
+        end_time = time.perf_counter_ns()
+        bench_api_metrics_snapshot()
+        standard_metrics = bench_api_metrics_collect()
+        
+        stats = new_table([
+            double_col("elapsed_nanos", [end_time - begin_time]),
+            long_col("processed_row_count", [${consumerResultSize}]),
+            long_col("result_row_count", [${resultTableSize}])
+        ])
+        """;
+        query = query.replace("${awaitTableLoad}", getTableWaiter(operation));
+        query = query.replace("${consumerResultSize}", getConsumerResultSize(operation));
+        query = query.replace("${resultTableSize}", getResultTableSize(operation));
+        query = query.replace("${rowCount}", "" + rowCount);
+        query = query.replace("${tableType}", tableType);
+        query = query.replace("${operation}", operation);
+        query = query.replace("${kafkaConsumerSpec}", getKafkaConsumerSpec(colCount, getDHType(colType)));
+        query = query.replace("${schemaRegistryURL}", getSchemaRegistry());
+
+
+        api.query(query).fetchAfter("stats", table -> {
+            long elapsedNanos = table.getSum("elapsed_nanos").longValue();
+            long procRowCount = table.getSum("processed_row_count").longValue();
+            long resultRowCount = table.getSum("result_row_count").longValue();
+            assertEquals(rowCount, procRowCount, "Wrong processed row count");
+            assertEquals(1, resultRowCount, "Wrong counter table row count");
+            api.result().test("deephaven-engine", Duration.ofNanos(elapsedNanos), rowCount);
+        }).fetchAfter("standard_metrics", table -> {
+            api.metrics().add(table);
+        }).execute();
+    }
+
+    private String getSchemaRegistry() {
+        if (!generatorType.equals("avro")) {
+            return "";
+        }
+        return ", 'schema.registry.url' : 'http://${schema.registry.addr}'";
+    }
+
+    private String getKafkaConsumerSpec(int colCount, String colType) {
+        if (generatorType.equals("avro")) {
+            return "kc.avro_spec('consumer_tbl_record', schema_version='1')";
+        }
+        var spec = """
+        [('count', dht.long)]
+        for i in range(1, ${colCount}):
+            kc_spec.append(('col' + str(i + 1), dht.${colType}))
+        kc_spec = kc.json_spec(kc_spec)
+        """;
+        return spec.replace("${colCount}", "" + colCount).replace("${colType}", "" + colType);
+    }
+
+    private String getTableWaiter(String operation) {
+        if (operation.equals("None")) {
+            return "bench_api_await_table_size(consumer_tbl, ${rowCount})";
+        }
+        return "bench_api_await_column_value_limit(result, 'count', ${rowCount})";
+    }
+
+    private String getConsumerResultSize(String operation) {
+        if (operation.equals("None")) {
+            return "consumer_tbl.size";
+        }
+        return "result.j_object.getColumnSource('count').get(0)";
+    }
+
+    private String getResultTableSize(String operation) {
+        if (operation.equals("None")) {
+            return "1";
+        }
+        return "result.size";
+    }
+
+    private void restartDocker(Bench api, int heapGigs) {
+        String dockerComposeFile = api.property("docker.compose.file", "");
+        if (dockerComposeFile.isBlank())
+            return;
+        dockerComposeFile = makeHeapAdjustedDockerCompose(dockerComposeFile, heapGigs);
+        var timer = api.timer();
+        Exec.restartDocker(dockerComposeFile);
+        var metrics = new Metrics(Timer.now(), "test-runner", "setup", "docker");
+        metrics.set("restart", timer.duration().toMillis(), "standard");
+        api.metrics().add(metrics);
+    }
+
+    // Replace heap (e.g. -Xmx64g) in docker-compose.yml with new heap value
+    private String makeHeapAdjustedDockerCompose(String dockerComposeFile, int heapGigs) {
+        Path sourceComposeFile = Paths.get(dockerComposeFile);
+        String newComposeName = sourceComposeFile.getFileName().toString().replace(".yml", "." + heapGigs + "g.yml");
+        Path destComposeFile = sourceComposeFile.resolveSibling(newComposeName);
+        String composeText = Filer.getFileText(sourceComposeFile);
+        composeText = composeText.replaceAll("[-]Xmx[0-9]+[gG]", "-Xmx" + heapGigs + "g");
+        Filer.putFileText(destComposeFile, composeText);
+        return destComposeFile.toString();
+    }
+
+    private String getDHType(String genColType) {
+        switch (genColType) {
+            case "int":
+                return "int32";
+            case "timestamp-millis":
+                return "Instant";
+            default:
+                return genColType;
+        }
+    }
+
+}

--- a/src/main/java/io/deephaven/benchmark/api/Snippets.java
+++ b/src/main/java/io/deephaven/benchmark/api/Snippets.java
@@ -51,6 +51,28 @@ class Snippets {
                     table.j_table.awaitUpdate()
         """;
 
+
+    /**
+     * Captures the value of the first column in a table every Deephaven ticking interval and does not allow advancement
+     * in the current query logic until that value is reached
+     * <p/>
+     * ex. bench_api_await_column_value_limit(table, 'count', 1000000)
+     * 
+     * @param table the table to monitor
+     * @param column the column name to monitor
+     * @param limit the upper bound for the monitored column value
+     */
+    static String bench_api_await_column_value_limit = """
+        from deephaven.table import Table
+        from deephaven.update_graph import exclusive_lock
+        def bench_api_await_column_value_limit(table: Table, column: str, limit: int):
+            with exclusive_lock(table):
+                value = 0
+                while value < limit:
+                    table.j_table.awaitUpdate()
+                    value = table.j_object.getColumnSource(column).get(0)
+        """;
+
     /**
      * Take a snapshot of a selection of JVM statistics. Multiple snapshots can be made in one query with each producing
      * a set of metrics that can be collected by <code>bench_api_metrics_collect</code>
@@ -124,6 +146,7 @@ class Snippets {
         functionDefs += getFunction("bench_api_await_table_size", bench_api_await_table_size, query);
         functionDefs += getFunction("bench_api_metrics_snapshot", bench_api_metrics_snapshot, query);
         functionDefs += getFunction("bench_api_metrics_collect", bench_api_metrics_collect, query);
+        functionDefs += getFunction("bench_api_await_column_value_limit", bench_api_await_column_value_limit, query);
         return functionDefs;
     }
 

--- a/src/main/java/io/deephaven/benchmark/util/Filer.java
+++ b/src/main/java/io/deephaven/benchmark/util/Filer.java
@@ -1,10 +1,7 @@
 /* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.util;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -41,9 +38,23 @@ public class Filer {
      */
     static public String getFileText(Path file) {
         try {
-            return new String(Files.readAllBytes(file)).replace("\r", "").trim();
+            return new String(Files.readString(file)).replace("\r", "").trim();
         } catch (Exception ex) {
             throw new RuntimeException("Failed to get text contents of file: " + file, ex);
+        }
+    }
+
+    /**
+     * Write the given text to a file. Create if the file does not exist. Overwrite if it exists.
+     * 
+     * @param file the file to contain the text
+     * @param text the text to write to the file
+     */
+    static public void putFileText(Path file, String text) {
+        try (BufferedWriter out = Files.newBufferedWriter(file)) {
+            out.append(text);
+        } catch (Exception ex) {
+            throw new RuntimeException("Failed to put text to file: " + file, ex);
         }
     }
 

--- a/src/test/java/io/deephaven/benchmark/util/FilerTest.java
+++ b/src/test/java/io/deephaven/benchmark/util/FilerTest.java
@@ -15,6 +15,14 @@ public class FilerTest {
     }
 
     @Test
+    public void putFileText() throws Exception {
+        Path p = Paths.get(getClass().getResource("filertest.txt").toURI());
+        p = p.resolveSibling("filtertest2.txt");
+        Filer.putFileText(p, "One Two\nThree Four");
+        assertEquals("One Two\nThree Four", Files.readString(p), "Wrong file text");
+    }
+
+    @Test
     public void getUrlText() throws Exception {
         URL url = getClass().getResource("filertest.txt");
         assertEquals("One Two Three\nFour Five Six", Filer.getURLText(url), "Wrong file text");


### PR DESCRIPTION
Added some kafka benchmarks for measuring DH Kafka consume speed. Tests that use TableType.append() are no-op tests that measure topic consumption into a table. Tests that use TableType.blink() use count_by() to determine when the test is finished.

Highlights:
- Kafka tests with varying heap
- Kafka tests with varying table width
- Kafka tests with varying types

[2023-05-25_kafka_processing_rates.csv](https://github.com/deephaven/benchmark/files/11570210/2023-05-25_kafka_processing_rates.csv)