### PR TITLE
Reworked fixed vs random naming to avoid confusion with distribution names

### DIFF
--- a/docs/TestWritingBasics.md
+++ b/docs/TestWritingBasics.md
@@ -22,7 +22,7 @@ api.table("stock_trans").fixed()
 This generates a parquet file on the server with the path *data/stock_trans.parquet* for use in subsequent queries.
 
 ### Table Behavior:
-Define table generation for column data distribution and row count limits according to the following contract:
+Define table generation for default column data distribution and row count limits according to the following contract:
 - default
   - The generated table row count is limited only by the _scale.row.count_ property, unless overridden by
     _withRowCount()_. The column ranges have no effect on the generated row count.

--- a/docs/TestWritingBasics.md
+++ b/docs/TestWritingBasics.md
@@ -12,7 +12,7 @@ There is no need to memorize a class structure for the API.  Everthing starts fr
 ## Table Generation
 Table data can be produced by defining columns, types, and sample data.
 ````
-api.table("stock_trans").random()
+api.table("stock_trans").fixed()
 	.add("symbol", "string", "SYM[1-1000]")
 	.add("price", "float", "[100-200]")
 	.add("buys", "int", "[1-100]")
@@ -21,9 +21,17 @@ api.table("stock_trans").random()
 ````
 This generates a parquet file on the server with the path *data/stock_trans.parquet* for use in subsequent queries.
 
-### Table Types:
-- random: Will choose random values for each column range inclusive of the boundaries
-- fixed: Will iterate through the range inclusive of the boundaries.  Table row count will be the longest range.
+### Table Behavior:
+Define table generation for column data distribution and row count limits according to the following contract:
+- default
+  - The generated table row count is limited only by the _scale.row.count_ property, unless overridden by
+    _withRowCount()_. The column ranges have no effect on the generated row count.
+  - The default distribution for column data is "random"
+- fixed()
+  - The generated table row count grows to the largest range of all column definitions, unless that is overridden
+    by _withRowCount()_. So if col1 is [1-10] and col2 is [1-20] the generated row count is 20. Using _withRowCount(30)_
+    would make the generated row count 30. Using _withRowCount(5)_ would make the generated row count 5.
+  - The default distribution for column data is "incremental"
 
 ### Column Types:
 - string

--- a/src/it/java/io/deephaven/benchmark/tests/experimental/ExperimentalTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/experimental/ExperimentalTestRunner.java
@@ -235,7 +235,7 @@ public class ExperimentalTestRunner {
     }
 
     void generateQuotesTable(long rowCount) {
-        api.table("quotes_g").random()
+        api.table("quotes_g")
                 .add("Date", "string", "2023-01-04")
                 .add("Sym", "string", "S[1-431]")
                 .add("Timestamp", "timestamp-millis", "[1-21600000]")
@@ -248,7 +248,7 @@ public class ExperimentalTestRunner {
     }
 
     void generateTradesTable(long rowCount) {
-        api.table("trades_g").random()
+        api.table("trades_g")
                 .add("Date", "string", "2023-01-04")
                 .add("Sym", "string", "S[1-430]")
                 .add("Timestamp", "timestamp-millis", "[1-21600000]")

--- a/src/it/java/io/deephaven/benchmark/tests/experimental/mergescale/ScaleTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/experimental/mergescale/ScaleTestRunner.java
@@ -90,7 +90,7 @@ class ScaleTestRunner {
     }
 
     void generateTable(String tableName, long rowCount) {
-        api.table(tableName).random()
+        api.table(tableName)
                 .add("int250", "int", "[1-250]")
                 .add("int640", "int", "[1-640]")
                 .add("int1M", "int", "[1-1000000]")

--- a/src/it/java/io/deephaven/benchmark/tests/internal/KafkaToParquetStreamTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/KafkaToParquetStreamTest.java
@@ -10,7 +10,7 @@ public class KafkaToParquetStreamTest {
 
     @Test
     public void makeParquetFile() {
-        api.table("orders").random()
+        api.table("orders")
                 .add("symbol", "string", "SYM[1-1000]")
                 .add("price", "float", "[10-20]")
                 .add("qty", "int", "1")

--- a/src/it/java/io/deephaven/benchmark/tests/internal/examples/stream/JoinTablesFromKafkaStreamTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/examples/stream/JoinTablesFromKafkaStreamTest.java
@@ -24,7 +24,7 @@ public class JoinTablesFromKafkaStreamTest {
 
         api.awaitCompletion();
 
-        api.table("stock_trans").random()
+        api.table("stock_trans")
                 .add("symbol", "string", "SYM[1-10000]")
                 .add("price", "float", "[100-200]")
                 .add("buys", "int", "[1-100]")

--- a/src/it/java/io/deephaven/benchmark/tests/internal/examples/stream/JoinTablesFromParquetAndStreamTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/examples/stream/JoinTablesFromParquetAndStreamTest.java
@@ -22,7 +22,7 @@ public class JoinTablesFromParquetAndStreamTest {
                 .add("exchange", "string", "EXCHANGE[1-10]")
                 .generateParquet();
 
-        api.table("stock_trans").random()
+        api.table("stock_trans")
                 .add("symbol", "string", "SYM[1-10000]")
                 .add("price", "float", "[100-200]")
                 .add("buys", "int", "[1-100]")

--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -303,7 +303,7 @@ public class StandardTestRunner {
     }
 
     void generateSourceTable(String distribution) {
-        api.table("source").random()
+        api.table("source")
                 .add("int250", "int", "[1-250]", distribution)
                 .add("int640", "int", "[1-640]", distribution)
                 .add("int1M", "int", "[1-1000000]", distribution)

--- a/src/it/java/io/deephaven/benchmark/tests/standard/parquet/ParquetTestSetup.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/parquet/ParquetTestSetup.java
@@ -46,7 +46,7 @@ class ParquetTestSetup {
     }
 
     void generateCompressedTable(String codec) {
-        api.table("compressed").random()
+        api.table("compressed")
                 .add("str100K", "string", "SYM[1-100000]")
                 .add("str10K", "string", "SYM[1-10000]")
                 .add("long100K", "long", "[1-100000]")

--- a/src/main/java/io/deephaven/benchmark/generator/ColumnDefs.java
+++ b/src/main/java/io/deephaven/benchmark/generator/ColumnDefs.java
@@ -35,12 +35,12 @@ public class ColumnDefs {
     }
 
     /**
-     * Get whether or not column values are selected incrementally through the range or random
+     * Set the default column distribution for columns that do not have a distribution defined.
      * 
-     * @return true if incremental/fixed, otherwise false.
+     * @param distribution the distribution name (e.g. {@code random | incremental})
      */
-    public boolean isFixed() {
-        return "incremental".equals(defaultDistribution);
+    public void setDefaultDistribution(String distribution) {
+        defaultDistribution = distribution;
     }
 
     /**
@@ -75,26 +75,12 @@ public class ColumnDefs {
     }
 
     /**
-     * Set all column definitions to generate data incrementally.
-     */
-    public void setFixed() {
-        defaultDistribution = "incremental";
-    }
-
-    /**
-     * Set all column definitions to generate data randomly.
-     */
-    public void setRandom() {
-        defaultDistribution = "random";
-    }
-
-    /**
      * Add a new column definition.
      * 
      * @param name the column name
      * @param type the column type
      * @param valueDef the range data (ex. "[1-10]", "str[1-100]ing")
-     * @param distribution override default distribution function (random, fixed) with another one, or null
+     * @param distribution override default distribution function (e.g. random, incremental) with another one, or null
      * @return this
      */
     public ColumnDefs add(String name, String type, String valueDef, String distribution) {
@@ -109,8 +95,7 @@ public class ColumnDefs {
     }
 
     /**
-     * Get the next value for the column in the given index. This supports incremental and random retrieval of the
-     * column next column value according to <code>isFixed</code>
+     * Get the next value for the column in the given index according to the columns defined distribution.
      * 
      * @param columnIndex the index of the column
      * @param seed a value to use to get the next value (e.g. row id)

--- a/src/test/java/io/deephaven/benchmark/generator/ColumnDefsTest.java
+++ b/src/test/java/io/deephaven/benchmark/generator/ColumnDefsTest.java
@@ -14,7 +14,7 @@ public class ColumnDefsTest {
                 .add("symbol", "string", "ABC[1-11]")
                 .add("price", "float", "[100-105]")
                 .add("priceAgain", "int", "[100-105]");
-        columnDefs.setFixed();
+        columnDefs.setDefaultDistribution("incremental");
 
         assertEquals(3, columnDefs.columns.size(), "Wrong def count");
 
@@ -95,7 +95,7 @@ public class ColumnDefsTest {
                 .add("symbol", "string", "ABC[1-10]")
                 .add("price", "float", "[100-105]")
                 .add("priceAgain", "int", "[100-105]", "linearConv");
-        columnDefs.setFixed();
+        columnDefs.setDefaultDistribution("incremental");
 
         assertEquals("""
                 name,type,values,distribution
@@ -107,9 +107,9 @@ public class ColumnDefsTest {
     }
 
     @Test
-    public void nextValue_Fixed() {
+    public void nextValue_Incremental() {
         ColumnDefs columnDefs = new ColumnDefs(5).add("v", "string", "s[1-7]");
-        columnDefs.setFixed();
+        columnDefs.setDefaultDistribution("incremental");
 
         var vals = IntStream.range(0, 10).mapToObj(i -> columnDefs.nextValue(0, i, 10)).toList();
         assertEquals("[s1, s2, s3, s4, s5, s6, s7, s1, s2, s3]", vals.toString(), "Wrong generated sequence");
@@ -130,13 +130,13 @@ public class ColumnDefsTest {
     @Test
     public void nextValue_Random() {
         var columnDefs1 = new ColumnDefs(5).add("v", "string", "s[1-7]");
-        columnDefs1.setRandom();
+        columnDefs1.setDefaultDistribution("random");
 
         var vals = IntStream.range(0, 10).mapToObj(i -> columnDefs1.nextValue(0, i, 10)).toList();
         assertEquals("[s6, s6, s1, s2, s1, s5, s7, s1, s6, s5]", vals.toString(), "Wrong generated sequence");
 
         var columnDefs2 = new ColumnDefs(5).add("v", "string", "s[1-7]");
-        columnDefs2.setRandom();
+        columnDefs1.setDefaultDistribution("random");
 
         Map<String, Set<Integer>> unique = new LinkedHashMap<>();
 


### PR DESCRIPTION
- Removed random() table directive.  It is the default, so no need to have an explicit call.
- fixed() table directive remains the same (default distro is "incremental" when set and row count is max column range except if withRowCount() overrides)
- Updated Readme docs on the subject.
- Removed unncessary random() from table definitions in tests