### PR TITLE
Improved Docker Restart Time Between Benchmarks

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/experimental/ExperimentalTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/experimental/ExperimentalTestRunner.java
@@ -231,7 +231,8 @@ public class ExperimentalTestRunner {
 
     void restartDocker(Bench api) {
         var dockerComposeFile = api.property("docker.compose.file", "");
-        Exec.restartDocker(dockerComposeFile);
+        var deephavenHostPort = api.property("deephaven.addr", "");
+        Exec.restartDocker(dockerComposeFile, deephavenHostPort);
     }
 
     void generateQuotesTable(long rowCount) {

--- a/src/it/java/io/deephaven/benchmark/tests/experimental/mergescale/ScaleTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/experimental/mergescale/ScaleTestRunner.java
@@ -82,7 +82,7 @@ class ScaleTestRunner {
 
     void restartDocker(Bench api) {
         var timer = api.timer();
-        if (!Exec.restartDocker(api.property("docker.compose.file", "")))
+        if (!Exec.restartDocker(api.property("docker.compose.file", ""), api.property("deephaven.addr", "")))
             return;
         var metrics = new Metrics(Timer.now(), "test-runner", "setup", "docker");
         metrics.set("restart", timer.duration().toMillis(), "standard");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -279,7 +279,7 @@ public class StandardTestRunner {
 
     void restartDocker(Bench api) {
         var timer = api.timer();
-        if (!Exec.restartDocker(api.property("docker.compose.file", "")))
+        if (!Exec.restartDocker(api.property("docker.compose.file", ""), api.property("deephaven.addr", "")))
             return;
         var metrics = new Metrics(Timer.now(), "test-runner", "setup", "docker");
         metrics.set("restart", timer.duration().toMillis(), "standard");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaTestRunner.java
@@ -181,11 +181,12 @@ class KafkaTestRunner {
 
     private void restartDocker(Bench api, int heapGigs) {
         String dockerComposeFile = api.property("docker.compose.file", "");
-        if (dockerComposeFile.isBlank())
+        String deephavenHostPort = api.property("deephaven.addr", "");
+        if (dockerComposeFile.isBlank() || deephavenHostPort.isBlank())
             return;
         dockerComposeFile = makeHeapAdjustedDockerCompose(dockerComposeFile, heapGigs);
         var timer = api.timer();
-        Exec.restartDocker(dockerComposeFile);
+        Exec.restartDocker(dockerComposeFile, deephavenHostPort);
         var metrics = new Metrics(Timer.now(), "test-runner", "setup", "docker");
         metrics.set("restart", timer.duration().toMillis(), "standard");
         api.metrics().add(metrics);

--- a/src/it/java/io/deephaven/benchmark/tests/standard/parquet/ParquetTestSetup.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/parquet/ParquetTestSetup.java
@@ -38,7 +38,7 @@ class ParquetTestSetup {
 
     void restartDocker(Bench api) {
         var timer = api.timer();
-        if (!Exec.restartDocker(api.property("docker.compose.file", "")))
+        if (!Exec.restartDocker(api.property("docker.compose.file", ""), api.property("deephaven.addr", "")))
             return;
         var metrics = new Metrics(Timer.now(), "test-runner", "setup", "docker");
         metrics.set("restart", timer.duration().toMillis(), "standard");


### PR DESCRIPTION
Changes
- Reworked docker restart to use a 0 grace period on "down".  That doesn't mean that `docker compose down` takes 0 seconds but that the DH and Redpanda services stop immediately and docker does any other container/volume cleanup.
- Reworked DH start to poll the ide port (e.g. 10000) for a response of 200 OK.

Results Before/After Restart Change
- Before: 6.8 seconds
- After: 4.2 seconds
- Improvement:  38%
