### PR TITLE
Updated time and rolling_wavg to the new ways

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/internal/examples/stream/JoinTablesFromParquetAndStreamTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/examples/stream/JoinTablesFromParquetAndStreamTest.java
@@ -45,7 +45,6 @@ public class JoinTablesFromParquetAndStreamTest {
         api.setName("Join Two Tables Using Parquet File Views");
 
         var query = """
-        from deephaven.time import now
         from deephaven import agg
         from deephaven.parquet import read
 
@@ -98,7 +97,6 @@ public class JoinTablesFromParquetAndStreamTest {
         api.setName("Join Two Tables Using Incremental Release of Parquet File Records");
 
         var query = """
-        from deephaven.time import now
         from deephaven import agg
         from deephaven.parquet import read
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTickTest.java
@@ -50,9 +50,9 @@ public class RollingWAvgTickTest {
     public void rollingWAvgTick2Groups3OpsFloat() {
         runner.setScaleFactors(2, 1);
         var setup = """
-        contains_row = rolling_wavg_tick(weight_col='int10', cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
-        before_row = rolling_wavg_tick(weight_col='int10', cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)
-        after_row = rolling_wavg_tick(weight_col='int10', cols=["After = float5"], rev_ticks=-1, fwd_ticks=3)
+        contains_row = rolling_wavg_tick('int10', cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
+        before_row = rolling_wavg_tick('int10', cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)
+        after_row = rolling_wavg_tick('int10', cols=["After = float5"], rev_ticks=-1, fwd_ticks=3)
         """;
         runner.addSetupQuery(setup);
 


### PR DESCRIPTION
Fixed breaking changes introduce recently in DHC.
- Fixed test that used _from deephaven.time import now_  (Removed the import and use the Java _now_ DateTimeUtils formula)
- Fixed tests for rolling_wavg_tick that were using the old weight_col (Removed the param name)