### PR TITLE
PyFlink comparison benchmarks

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/compare/CompareTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/compare/CompareTestRunner.java
@@ -27,7 +27,7 @@ import io.deephaven.benchmark.util.Filer;
  */
 public class CompareTestRunner {
     final Object testInst;
-    final List<String> pipPackages = new ArrayList<>();
+    final Set<String> requiredPackages = new LinkedHashSet<>();
     private Bench api = null;
 
     public CompareTestRunner(Object testInst) {
@@ -66,7 +66,8 @@ public class CompareTestRunner {
     public void initPython(String... packages) {
         restartDocker(1);
         initialize(testInst);
-        pipPackages.addAll(Arrays.asList(packages));
+        requiredPackages.addAll(Arrays.asList(packages));
+        requiredPackages.add("install-jdk");
     }
 
     /**
@@ -97,8 +98,8 @@ public class CompareTestRunner {
     public void test(String name, long expectedRowCount, String setup, String operation, String mainSizeGetter,
             String resultSizeGetter) {
         Result result;
-        if (pipPackages.size() > 0) {
-            installPipPackages();
+        if (requiredPackages.size() > 0) {
+            installRequiredPackages();
             result = runPythonTest(name, setup, operation, mainSizeGetter, resultSizeGetter);
         } else {
             result = runDeephavenTest(name, setup, operation, mainSizeGetter, resultSizeGetter);
@@ -106,13 +107,16 @@ public class CompareTestRunner {
         var rcount = result.resultRowCount();
         var ecount = (expectedRowCount < 1) ? Long.MAX_VALUE : expectedRowCount;
         assertTrue(rcount > 0 && rcount <= ecount, "Wrong result row count: " + rcount);
+        System.out.println("Result Count: " + rcount);
     }
 
     /**
-     * Tell Deephaven to install python packages using pip in its environment. Note: This assumes that after these
-     * packages are installed, Deephaven will only be used as an agent to run command line python code
+     * Tell Deephaven to install required python or java packages in its environment. Note: This assumes that after
+     * these packages are installed, Deephaven will only be used as an agent to run command line python code
      */
-    void installPipPackages() {
+    void installRequiredPackages() {
+        var pipPackages = requiredPackages.stream().filter(p -> !isJavaPackage(p)).toList();
+
         var query = """
         text = '''PACKAGES='${pipPackages}'
         VENV_PATH=~/deephaven-benchmark-venv
@@ -123,9 +127,35 @@ public class CompareTestRunner {
             ./bin/pip install ${PKG}
         done
         '''
-        run_script('bash', 'setup-benchmark-workspace.sh', text)
+        save_file('setup-benchmark-workspace.sh', text)
+        run_script('bash', 'setup-benchmark-workspace.sh')
         """;
         query = query.replace("${pipPackages}", String.join(" ", pipPackages));
+        api.query(query).execute();
+
+        requiredPackages.forEach(p -> installJavaPackage(p));
+    }
+
+    boolean isJavaPackage(String javaDescr) {
+        return javaDescr.matches("jdk-[0-9]+");
+    }
+
+    void installJavaPackage(String javaDescr) {
+        if (!isJavaPackage(javaDescr))
+            return;
+        var version = javaDescr.replaceAll("jdk-([0-9]+)", "$1");
+        var query = """
+        text = '''
+        import os, jdk
+        if not os.path.exists('./jdk-${version}'):
+            jdk.install('11', vendor='Temurin', path='./')
+            os.system('mv jdk*/ jdk-${version}')
+            os.system('echo JAVA_HOME=$PWD/jdk-${version} > ENV_VARS.sh')
+        '''
+        save_file('install-jdk.py', text)
+        run_script('./bin/python', 'install-jdk.py')
+        """;
+        query = query.replace("${version}", String.join(" ", version));
         api.query(query).execute();
     }
 
@@ -143,7 +173,7 @@ public class CompareTestRunner {
         var query = """
         begin_time = time.perf_counter_ns()
         ${setupQueries}
-        result = ${operation}
+        ${operation}
         op_duration = time.perf_counter_ns() - begin_time
         
         stats = new_table([
@@ -166,10 +196,20 @@ public class CompareTestRunner {
      */
     Result runPythonTest(String name, String setup, String operation, String mainSizeGetter, String resultSizeGetter) {
         var query = """
+        text = '''#!/usr/bin/env bash
+        touch ENV_VARS.sh
+        source ENV_VARS.sh
+        ./bin/python $1
+        '''
+        save_file('run-benchmark-test.sh', text)
+        """;
+        api.query(query).execute();
+
+        query = """
         text = '''import time
-        begin_time = time.perf_counter_ns()
         ${setupQueries}
-        result = ${operation}
+        begin_time = time.perf_counter_ns()
+        ${operation}
         op_duration = time.perf_counter_ns() - begin_time
         main_size = ${mainSizeGetter}
         result_size = ${resultSizeGetter}
@@ -177,7 +217,8 @@ public class CompareTestRunner {
         print("-- Test Results --")
         print("{", "'duration':", op_duration, ", 'main_size':", main_size, ", 'result_size':", result_size, "}")
         '''
-        result = run_script('./bin/python', 'benchmark-test.py', text)
+        save_file('benchmark-test.py', text)
+        result = run_script('./run-benchmark-test.sh', 'benchmark-test.py')
         result = eval(result.splitlines()[-1])
         
         stats = new_table([
@@ -224,11 +265,16 @@ public class CompareTestRunner {
 
         user_home = str(Path.home())
         benchmark_home = user_home + '/deephaven-benchmark-venv'
-
-        def run_script(runner, script_name, script_text):
+        
+        def save_file(file_name, file_text):
             os.makedirs(benchmark_home, exist_ok=True)
-            with open(benchmark_home + '/' + script_name, 'w') as f:
-                f.write(script_text)
+            file_path = benchmark_home + '/' + file_name
+            with open(file_path, 'w') as f:
+                f.write(file_text)
+            st = os.stat(file_path)
+            os.chmod(file_path, st.st_mode | stat.S_IEXEC)
+
+        def run_script(runner, script_name):
             command_array = [runner, script_name]
             output=subprocess.check_output(command_array, cwd=benchmark_home).decode("utf-8")
             print(output)

--- a/src/it/java/io/deephaven/benchmark/tests/compare/Setup.java
+++ b/src/it/java/io/deephaven/benchmark/tests/compare/Setup.java
@@ -1,22 +1,52 @@
 package io.deephaven.benchmark.tests.compare;
 
 public class Setup {
-    static public String flink = """
-    import time
-    import pandas as pd
-    from pyflink.common import Row
-    from pyflink.table import (EnvironmentSettings, TableEnvironment, TableDescriptor, Schema, DataTypes, FormatDescriptor)
-    from pyflink.table.expressions import lit, col
-    from pyflink.table.udf import udtf
+    static public String flink(CompareTestRunner r) {
+        addDownloadJar(r, "flink", "flink-sql-parquet", "1.17.1");
+        addDownloadJar(r, "flink", "flink-oss-fs-hadoop", "1.17.1");
+        addDownloadJar(r, "hadoop", "hadoop-mapreduce-client-core", "2.10.2");
+        
+        var q = """
+        import time, os
+        import pandas as pd
+        from pyflink.common import Row
+        from pyflink.table import (EnvironmentSettings, TableEnvironment)
+        from pyflink.table.expressions import lit, col
+        from pyflink.table.udf import udtf
 
-    t_env = TableEnvironment.create(EnvironmentSettings.in_batch_mode())
-    t_env.get_config().set("parallelism.default", "16")
+        t_env = TableEnvironment.create(EnvironmentSettings.in_batch_mode())
+        t_env.get_config().set("parallelism.default", "1")
+        t_env.get_config().set("taskmanager.memory.process.size", "24g")
+        t_env.get_config().set("jobmanager.memory.process.size", "24g")
+        t_env.get_config().set("python.fn-execution.arrow.batch.size", "10000000")
+        t_env.get_config().set("python.fn-execution.bundle.size", "10000000")
+        t_env.get_config().set("python.state.cache-size", "10000000")
+        t_env.get_config().set("python.map-state.iterate-response-batch-size", "10000000")
+        t_env.get_config().set("python.map-state.read-cache-size", "10000000")
+        t_env.get_config().set("python.map-state.write-cache-size", "10000000")
+        t_env.get_config().set("python.metric.enabled", "false")
+        t_env.get_config().set("python.operator-chaining.enabled", "true")
+        
+        os.system('rm -rf /data/results.csv')
 
-    def count_rows(table_result):
-        count = 0
-        with table_result.collect() as rows:
-            for row in rows:
-                count = count + 1
-        return count
-    """;
+        def count_rows(table_name):
+            sname = table_name + '_stats'
+            stats_dir = '/data/' + sname + '.csv'
+            os.system('rm -rf ' + stats_dir)
+            t_env.execute_sql("CREATE TABLE " + sname + "(row_count BIGINT) WITH ('connector'='filesystem','path'='" + stats_dir + "','format'='csv')")
+            t_env.execute_sql("INSERT INTO " + sname + " SELECT count(*) AS row_count FROM " + table_name).wait()
+            count = 0
+            for r in t_env.from_path(sname).execute().collect():
+                count = r[0]
+            return count
+        """;
+        return q;
+    }
+    
+    static public void addDownloadJar(CompareTestRunner r, String prod, String artifact, String version) {
+        var destDir = "lib/python3.10/site-packages/pyflink/lib";
+        var apacheUri = "https://repo1.maven.org/maven2/org/apache/";
+        var uri = apacheUri + prod + '/' + artifact + '/' + version + '/' + artifact + '-' + version + ".jar";
+        r.addDownloadFiles(uri, destDir);
+    }
 }

--- a/src/it/java/io/deephaven/benchmark/tests/compare/Setup.java
+++ b/src/it/java/io/deephaven/benchmark/tests/compare/Setup.java
@@ -1,0 +1,22 @@
+package io.deephaven.benchmark.tests.compare;
+
+public class Setup {
+    static public String flink = """
+    import time
+    import pandas as pd
+    from pyflink.common import Row
+    from pyflink.table import (EnvironmentSettings, TableEnvironment, TableDescriptor, Schema, DataTypes, FormatDescriptor)
+    from pyflink.table.expressions import lit, col
+    from pyflink.table.udf import udtf
+
+    t_env = TableEnvironment.create(EnvironmentSettings.in_batch_mode())
+    t_env.get_config().set("parallelism.default", "16")
+
+    def count_rows(table_result):
+        count = 0
+        with table_result.collect() as rows:
+            for row in rows:
+                count = count + 1
+        return count
+    """;
+}

--- a/src/it/java/io/deephaven/benchmark/tests/compare/distinct/DistinctTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/compare/distinct/DistinctTest.java
@@ -4,6 +4,7 @@ package io.deephaven.benchmark.tests.compare.distinct;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import io.deephaven.benchmark.tests.compare.CompareTestRunner;
+import io.deephaven.benchmark.tests.compare.Setup;
 
 /**
  * Product comparison tests for the distinct (or select distinct) group operation. Tests read the same parquet data. To
@@ -20,11 +21,11 @@ public class DistinctTest {
     @Order(1)
     public void deephavenDistinct() {
         runner.initDeephaven(2, "source", null, "int640", "str250");
-        var setup = """
-        from deephaven.parquet import read
+        var setup = "from deephaven.parquet import read";
+        var op = """
         source = read('/data/source.parquet').select()
+        result = source.select_distinct(formulas=['str250', 'int640'])
         """;
-        var op = "source.select_distinct(formulas=['str250', 'int640'])";
         var msize = "source.size";
         var rsize = "result.size";
         runner.test("Deephaven Distinct", setup, op, msize, rsize);
@@ -34,11 +35,11 @@ public class DistinctTest {
     @Order(2)
     public void pyarrowDistinct() {
         runner.initPython("pyarrow");
-        var setup = """
-        import pyarrow.dataset as ds
+        var setup = "import pyarrow.dataset as ds";
+        var op = """
         source = ds.dataset('/data/source.parquet', format="parquet").to_table()
+        result = source.group_by(['str250', 'int640']).aggregate([])
         """;
-        var op = "source.group_by(['str250', 'int640']).aggregate([])";
         var msize = "source.num_rows";
         var rsize = "result.num_rows";
         runner.test("PyArrow Distinct", setup, op, msize, rsize);
@@ -48,14 +49,29 @@ public class DistinctTest {
     @Order(3)
     public void pandasDistinct() {
         runner.initPython("fastparquet", "pandas");
-        var setup = """
-        import pandas as pd
+        var setup = "import pandas as pd";
+        var op = """
         source = pd.read_parquet('/data/source.parquet')
+        result = source.drop_duplicates(subset=['str250','int640'], keep='last')
         """;
-        var op = "source.drop_duplicates(subset=['str250','int640'], keep='last')";
         var msize = "len(source)";
         var rsize = "len(result)";
         runner.test("Pandas Distinct", setup, op, msize, rsize);
+    }
+
+    @Test
+    @Order(4)
+    public void flinkDistinct() {
+        runner.initPython("apache-flink", "jdk-11");
+        var op = """
+        source = pd.read_parquet('/data/source.parquet')
+        loaded_size = len(source)
+        source = t_env.from_pandas(source)
+        result = source.select(col('str250'), col('int640')).distinct().execute()
+        """;
+        var msize = "loaded_size";
+        var rsize = "count_rows(result)";
+        runner.test("Flink Distinct", Setup.flink, op, msize, rsize);
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/compare/distinct/DistinctTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/compare/distinct/DistinctTest.java
@@ -11,7 +11,10 @@ import io.deephaven.benchmark.tests.compare.Setup;
  * avoid an unfair advantage where some products may partition or group data during the read, parquet read time is
  * included in the benchmark results.
  * <p/>
- * Each test produces a table result that contains rows unique according to a string and an integer
+ * Each test produces a table result that contains rows unique according to a string and an integer.
+ * <p/>
+ * Data generation only happens in the first tests, the Deephaven test. Tests can be run individually, but only after
+ * the desired data has been generated.
  */
 @TestMethodOrder(OrderAnnotation.class)
 public class DistinctTest {
@@ -61,17 +64,18 @@ public class DistinctTest {
 
     @Test
     @Order(4)
+    @Disabled
     public void flinkDistinct() {
         runner.initPython("apache-flink", "jdk-11");
         var op = """
         source = pd.read_parquet('/data/source.parquet')
         loaded_size = len(source)
         source = t_env.from_pandas(source)
-        result = source.select(col('str250'), col('int640')).distinct().execute()
+        result = source.select(col('str250'), col('int640')).distinct().to_pandas()
         """;
         var msize = "loaded_size";
-        var rsize = "count_rows(result)";
-        runner.test("Flink Distinct", Setup.flink, op, msize, rsize);
+        var rsize = "len(result)";
+        runner.test("Flink Distinct", Setup.flink(runner), op, msize, rsize);
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/compare/filter/FilterTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/compare/filter/FilterTest.java
@@ -12,7 +12,10 @@ import io.deephaven.benchmark.tests.compare.Setup;
  * benchmark results.
  * <p/>
  * Each test produces a table result filtered by three criteria; value is an exact string, value > an integer, value <
- * an integer
+ * an integer.
+ * <p/>
+ * Data generation only happens in the first tests, the Deephaven test. Tests can be run individually, but only after
+ * the desired data has been generated.
  */
 @TestMethodOrder(OrderAnnotation.class)
 public class FilterTest {
@@ -63,20 +66,21 @@ public class FilterTest {
         var rsize = "len(result)";
         runner.test("Pandas Filter", setup, op, msize, rsize);
     }
-    
+
     @Test
     @Order(4)
+    @Disabled
     public void flinkFilter() {
         runner.initPython("apache-flink", "jdk-11");
         var op = """
         source = pd.read_parquet('/data/source.parquet')
         loaded_size = len(source)
         source = t_env.from_pandas(source)
-        result = source.filter((col('str250') == '250') & (col('int640') > 100) & (col('int640') < 540)).execute()
+        result = source.filter((col('str250') == '250') & (col('int640') > 100) & (col('int640') < 540)).to_pandas()
         """;
         var msize = "loaded_size";
-        var rsize = "count_rows(result)";
-        runner.test("Flink Filter", Setup.flink, op, msize, rsize);
+        var rsize = "len(result)";
+        runner.test("Flink Filter", Setup.flink(runner), op, msize, rsize);
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/compare/filter/FilterTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/compare/filter/FilterTest.java
@@ -4,6 +4,7 @@ package io.deephaven.benchmark.tests.compare.filter;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import io.deephaven.benchmark.tests.compare.CompareTestRunner;
+import io.deephaven.benchmark.tests.compare.Setup;
 
 /**
  * Product comparison tests for filter (where) operations. Tests read the same parquet data. To avoid an unfair
@@ -21,12 +22,10 @@ public class FilterTest {
     @Order(1)
     public void deephavenFilter() {
         runner.initDeephaven(2, "source", null, "str250", "int640");
-        var setup = """
-        from deephaven.parquet import read
-        source = read('/data/source.parquet').select()
-        """;
+        var setup = "from deephaven.parquet import read";
         var op = """
-        source.where(["str250 = '250'", "int640 > 100", "int640 < 540"]);
+        source = read('/data/source.parquet').select()
+        result = source.where(["str250 = '250'", "int640 > 100", "int640 < 540"])
         """;
         var msize = "source.size";
         var rsize = "result.size";
@@ -40,10 +39,12 @@ public class FilterTest {
         var setup = """
         import pyarrow.dataset as ds
         import pyarrow.compute as pc
+        """;
+        var op = """
         source = ds.dataset('/data/source.parquet', format="parquet").to_table()
         expr = (pc.field('str250') == '250') & (pc.field('int640') > 100) & (pc.field('int640') < 540)
+        result = source.filter(expr)
         """;
-        var op = "source.filter(expr)";
         var msize = "source.num_rows";
         var rsize = "result.num_rows";
         runner.test("PyArrow Filter", setup, op, msize, rsize);
@@ -53,16 +54,29 @@ public class FilterTest {
     @Order(3)
     public void pandasFilter() {
         runner.initPython("fastparquet", "pandas");
-        var setup = """
-        import pandas as pd
-        source = pd.read_parquet('/data/source.parquet')
-        """;
+        var setup = "import pandas as pd";
         var op = """
-        source.query("str250 == '250' & int640 > 100 & int640 < 540")
+        source = pd.read_parquet('/data/source.parquet')
+        result = source.query("str250 == '250' & int640 > 100 & int640 < 540")
         """;
         var msize = "len(source)";
         var rsize = "len(result)";
         runner.test("Pandas Filter", setup, op, msize, rsize);
+    }
+    
+    @Test
+    @Order(4)
+    public void flinkFilter() {
+        runner.initPython("apache-flink", "jdk-11");
+        var op = """
+        source = pd.read_parquet('/data/source.parquet')
+        loaded_size = len(source)
+        source = t_env.from_pandas(source)
+        result = source.filter((col('str250') == '250') & (col('int640') > 100) & (col('int640') < 540)).execute()
+        """;
+        var msize = "loaded_size";
+        var rsize = "count_rows(result)";
+        runner.test("Flink Filter", Setup.flink, op, msize, rsize);
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/compare/join/InnerJoinTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/compare/join/InnerJoinTest.java
@@ -7,11 +7,14 @@ import io.deephaven.benchmark.tests.compare.CompareTestRunner;
 import io.deephaven.benchmark.tests.compare.Setup;
 
 /**
- * Product comparison tests for inner join operations. Tests read the same parquet data. To avoid an unfair
- * advantage where some products may partition or group data during the read, parquet read time is included in the
- * benchmark results.
+ * Product comparison tests for inner join operations. Tests read the same parquet data. To avoid an unfair advantage
+ * where some products may partition or group data during the read, parquet read time is included in the benchmark
+ * results.
  * <p/>
- * Each test produces a table that is the result of two tables intersected by a string and an integer
+ * Each test produces a table that is the result of two tables intersected by a string and an integer.
+ * <p/>
+ * Data generation only happens in the first tests, the Deephaven test. Tests can be run individually, but only after
+ * the desired data has been generated.
  */
 @TestMethodOrder(OrderAnnotation.class)
 public class InnerJoinTest {
@@ -46,7 +49,7 @@ public class InnerJoinTest {
         var rsize = "result.num_rows";
         runner.test("PyArrow Inner Join", setup, op, msize, rsize);
     }
-    
+
     @Test
     @Order(3)
     public void pandasInnerJoin() {
@@ -61,9 +64,10 @@ public class InnerJoinTest {
         var rsize = "len(result)";
         runner.test("Pandas Inner Join", setup, op, msize, rsize);
     }
-    
+
     @Test
     @Order(4)
+    @Disabled
     public void flinkInnerJoin() {
         runner.initPython("apache-flink", "jdk-11");
         var op = """
@@ -72,11 +76,11 @@ public class InnerJoinTest {
         source = t_env.from_pandas(source)
         right = pd.read_parquet('/data/right.parquet')
         right = t_env.from_pandas(right)
-        result = source.join(right, (col('str250') == col('r_str250')) & (col('int1M') == col('r_int1M'))).execute()
+        result = source.join(right, (col('str250') == col('r_str250')) & (col('int1M') == col('r_int1M'))).to_pandas()
         """;
         var msize = "loaded_size";
-        var rsize = "count_rows(result)";
-        runner.test("Flink Inner Join", Setup.flink, op, msize, rsize);
+        var rsize = "len(result)";
+        runner.test("Flink Inner Join", Setup.flink(runner), op, msize, rsize);
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/compare/sort/SortTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/compare/sort/SortTest.java
@@ -7,11 +7,13 @@ import io.deephaven.benchmark.tests.compare.CompareTestRunner;
 import io.deephaven.benchmark.tests.compare.Setup;
 
 /**
- * Product comparison tests for sort operations. Tests read the same parquet data. To avoid an unfair
- * advantage where some products may partition or group data during the read, parquet read time is included in the
- * benchmark results.
+ * Product comparison tests for sort operations. Tests read the same parquet data. To avoid an unfair advantage where
+ * some products may partition or group data during the read, parquet read time is included in the benchmark results.
  * <p/>
- * Each test sorts a table by a string and an integer
+ * Each test sorts a table by a string and an integer.
+ * <p/>
+ * Data generation only happens in the first tests, the Deephaven test. Tests can be run individually, but only after
+ * the desired data has been generated.
  */
 @TestMethodOrder(OrderAnnotation.class)
 public class SortTest {
@@ -44,7 +46,7 @@ public class SortTest {
         var rsize = "result.num_rows";
         runner.test("PyArrow Sort", setup, op, msize, rsize);
     }
-    
+
     @Test
     @Order(3)
     public void pandasSort() {
@@ -58,20 +60,21 @@ public class SortTest {
         var rsize = "len(result)";
         runner.test("Pandas Sort", setup, op, msize, rsize);
     }
-    
+
     @Test
     @Order(4)
+    @Disabled
     public void flinkSort() {
         runner.initPython("apache-flink", "jdk-11");
         var op = """
         source = pd.read_parquet('/data/source.parquet')
         loaded_size = len(source)
         source = t_env.from_pandas(source)
-        result = source.order_by(col('str250'), col('int640')).execute()
+        result = source.order_by(col('str250'), col('int640')).to_pandas()
         """;
         var msize = "loaded_size";
-        var rsize = "loaded_size";    // count_rows takes for ever, so here we are
-        runner.test("Flink Sort", Setup.flink, op, msize, rsize);
+        var rsize = "len(result)";
+        runner.test("Flink Sort", Setup.flink(runner), op, msize, rsize);
     }
 
 }

--- a/src/main/resources/io/deephaven/benchmark/run/profile/compare-benchmark-summary.template.svg
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/compare-benchmark-summary.template.svg
@@ -109,14 +109,14 @@
       </header>
       <table cellspacing="0">
         <thead>
-          <tr><th>Benchmark</th><th>Deephaven<small class="rate"> (rows/sec)</small></th><th>PyArrow<small class="rate"> (rows/sec)</small></th><th>Pandas<small class="rate"> (rows/sec)</small></th><th>Flink<small class="rate"> (rows/sec)</small></th></tr>
+          <tr><th>Benchmark</th><th>Deephaven<small class="rate"> (rows/sec)</small></th><th>PyArrow<small class="rate"> (rows/sec)</small></th><th>Pandas<small class="rate"> (rows/sec)</small></th></tr>
         </thead>
       	<tbody>
-      	  <tr><td>Filters</td><td>${Deephaven Filter=>op_rate}</td><td>${PyArrow Filter=>op_rate}</td><td>${Pandas Filter=>op_rate}</td><td>${Flink Filter=>op_rate}</td></tr>
-      	  <tr><td>Distinct</td><td>${Deephaven Distinct=>op_rate}</td><td>${PyArrow Distinct=>op_rate}</td><td>${Pandas Distinct=>op_rate}</td><td>${Flink Distinct=>op_rate}</td></tr>
-      	  <tr><td>Average By</td><td>${Deephaven Average By=>op_rate}</td><td>${PyArrow Average By=>op_rate}</td><td>${Pandas Average By=>op_rate}</td><td>${Flink Average By=>op_rate}</td></tr>
-      	  <tr><td>Inner Join</td><td>${Deephaven Inner Join=>op_rate}</td><td>${PyArrow Inner Join=>op_rate}</td><td>${Pandas Inner Join=>op_rate}</td><td>${Flink Inner Join=>op_rate}</td></tr>
-      	  <tr><td>Sort</td><td>${Deephaven Sort=>op_rate}</td><td>${PyArrow Sort=>op_rate}</td><td>${Pandas Sort=>op_rate}</td><td>${Flink Sort=>op_rate}</td></tr>
+      	  <tr><td>Filters</td><td>${Deephaven Filter=>op_rate}</td><td>${PyArrow Filter=>op_rate}</td><td>${Pandas Filter=>op_rate}</td></tr>
+      	  <tr><td>Distinct</td><td>${Deephaven Distinct=>op_rate}</td><td>${PyArrow Distinct=>op_rate}</td><td>${Pandas Distinct=>op_rate}</td></tr>
+      	  <tr><td>Average By</td><td>${Deephaven Average By=>op_rate}</td><td>${PyArrow Average By=>op_rate}</td><td>${Pandas Average By=>op_rate}</td></tr>
+      	  <tr><td>Inner Join</td><td>${Deephaven Inner Join=>op_rate}</td><td>${PyArrow Inner Join=>op_rate}</td><td>${Pandas Inner Join=>op_rate}</td></tr>
+      	  <tr><td>Sort</td><td>${Deephaven Sort=>op_rate}</td><td>${PyArrow Sort=>op_rate}</td><td>${Pandas Sort=>op_rate}</td></tr>
       	</tbody>
       	<tfoot>
 		  <tr><td colspan="3">* cpu-threads=${dh_threads} heap=${dh_heap} os=${os_name} full-benchmark-set=${benchmark_count}</td></tr>

--- a/src/main/resources/io/deephaven/benchmark/run/profile/compare-benchmark-summary.template.svg
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/compare-benchmark-summary.template.svg
@@ -109,14 +109,14 @@
       </header>
       <table cellspacing="0">
         <thead>
-          <tr><th>Benchmark</th><th>Deephaven<small class="rate"> (rows/sec)</small></th><th>PyArrow<small class="rate"> (rows/sec)</small></th><th>Pandas<small class="rate"> (rows/sec)</small></th></tr>
+          <tr><th>Benchmark</th><th>Deephaven<small class="rate"> (rows/sec)</small></th><th>PyArrow<small class="rate"> (rows/sec)</small></th><th>Pandas<small class="rate"> (rows/sec)</small></th><th>Flink<small class="rate"> (rows/sec)</small></th></tr>
         </thead>
       	<tbody>
-      	  <tr><td>Filters</td><td>${Deephaven Filter=>op_rate}</td><td>${PyArrow Filter=>op_rate}</td><td>${Pandas Filter=>op_rate}</td></tr>
-      	  <tr><td>Distinct</td><td>${Deephaven Distinct=>op_rate}</td><td>${PyArrow Distinct=>op_rate}</td><td>${Pandas Distinct=>op_rate}</td></tr>
-      	  <tr><td>Average By</td><td>${Deephaven Average By=>op_rate}</td><td>${PyArrow Average By=>op_rate}</td><td>${Pandas Average By=>op_rate}</td></tr>
-      	  <tr><td>Inner Join</td><td>${Deephaven Inner Join=>op_rate}</td><td>${PyArrow Inner Join=>op_rate}</td><td>${Pandas Inner Join=>op_rate}</td></tr>
-      	  <tr><td>Sort</td><td>${Deephaven Sort=>op_rate}</td><td>${PyArrow Sort=>op_rate}</td><td>${Pandas Sort=>op_rate}</td></tr>
+      	  <tr><td>Filters</td><td>${Deephaven Filter=>op_rate}</td><td>${PyArrow Filter=>op_rate}</td><td>${Pandas Filter=>op_rate}</td><td>${Flink Filter=>op_rate}</td></tr>
+      	  <tr><td>Distinct</td><td>${Deephaven Distinct=>op_rate}</td><td>${PyArrow Distinct=>op_rate}</td><td>${Pandas Distinct=>op_rate}</td><td>${Flink Distinct=>op_rate}</td></tr>
+      	  <tr><td>Average By</td><td>${Deephaven Average By=>op_rate}</td><td>${PyArrow Average By=>op_rate}</td><td>${Pandas Average By=>op_rate}</td><td>${Flink Average By=>op_rate}</td></tr>
+      	  <tr><td>Inner Join</td><td>${Deephaven Inner Join=>op_rate}</td><td>${PyArrow Inner Join=>op_rate}</td><td>${Pandas Inner Join=>op_rate}</td><td>${Flink Inner Join=>op_rate}</td></tr>
+      	  <tr><td>Sort</td><td>${Deephaven Sort=>op_rate}</td><td>${PyArrow Sort=>op_rate}</td><td>${Pandas Sort=>op_rate}</td><td>${Flink Sort=>op_rate}</td></tr>
       	</tbody>
       	<tfoot>
 		  <tr><td colspan="3">* cpu-threads=${dh_threads} heap=${dh_heap} os=${os_name} full-benchmark-set=${benchmark_count}</td></tr>


### PR DESCRIPTION
- PyFlink comparison benchmarks with two types; Flink SQL or Python table api
   - Tests do work but are disabled, because they don't adequately fit the model of in-process single-operation queries like the other ones do
   - Flink benchmarks will not be included in the SVG summary, but will be kept for the possibility of further study later
- CompareTestRunner is similar to StandardTestRunner but does some things differently because of the nature of testing 3rd party packages
   - Run Python tests from the Deephaven container while using Deephaven as a test agent (e.g. 1G DH heap providing access to its Docker container)
   - Installation of _pip_ packages into a python virtual environment inside the same container Deephaven is running in
   - Installation of a different JDK (Flink 1.17 uses Java 11) into the same python venv
   - Download of remote URLs (e.g. jars from maven central) into a directory in the python venv
   - Tests ordered so Deephaven runs first and generates the parquet needed for the rest of the tests
   - Single test run is still supported, assuming the Deephaven test in the same Test Class has been run once before (This is a departure from the usual benchmark pattern where each test is self-contained as long as Deephaven is accessible.)
 
