### PR TITLE
RSync Benchmark Bucket to Demo Server

### DIFF
--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -78,6 +78,10 @@ jobs:
       with:
         path: ${{env.RUN_TYPE}}
         destination: deephaven-benchmark
+        
+    - name: Sync GCloud with Demo NFS
+      run: |
+        gcloud compute ssh --zone "us-central1-a" --project "deephaven-oss" dhc-demo-nfs-client --command="gsutil -m -q rsync -r -d -J -x '^.*/test-logs/.*$' gs://deephaven-benchmark deephaven-benchmark"
 
     - name: Archive Results
       uses: actions/upload-artifact@v3

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -81,7 +81,7 @@ jobs:
         
     - name: Sync GCloud with Demo NFS
       run: |
-        gcloud compute ssh --zone "us-central1-a" --project "deephaven-oss" dhc-demo-nfs-client --command="gsutil -m -q rsync -r -d -J -x '^.*/test-logs/.*$' gs://deephaven-benchmark deephaven-benchmark"
+        gcloud compute ssh --zone "us-central1-a" --project "deephaven-oss" dhc-demo-nfs-client --command="gsutil -m -q rsync -r -d -J -x '^.*/test-logs/.*$' gs://deephaven-benchmark /nfs/deephaven-benchmark"
 
     - name: Archive Results
       uses: actions/upload-artifact@v3

--- a/docs/BenchmarkDemo.md
+++ b/docs/BenchmarkDemo.md
@@ -17,7 +17,7 @@ or experiment with [the scripted UI](https://deephaven.io/core/docs/how-to-guide
 ```python
 from urllib.request import urlopen
 
-root = 'file:///data' if os.path.exists('/data/deephaven-benchmark') else 'https://storage.googleapis.com'
+root = 'file:///nfs' if os.path.exists('/nfs/deephaven-benchmark') else 'https://storage.googleapis.com'
 with urlopen(root + '/deephaven-benchmark/benchmark_tables.dh.py') as r:
     benchmark_storage_uri_arg = root + '/deephaven-benchmark'
     benchmark_category_arg = 'release'  # release | nightly

--- a/docs/PublishedResults.md
+++ b/docs/PublishedResults.md
@@ -10,7 +10,7 @@ in an instance of the Deephaven Engine.
 ````
 from urllib.request import urlopen
 
-root = 'file:///data' if os.path.exists('/data/deephaven-benchmark') else 'https://storage.googleapis.com'
+root = 'file:///nfs' if os.path.exists('/nfs/deephaven-benchmark') else 'https://storage.googleapis.com'
 with urlopen(root + '/deephaven-benchmark/benchmark_tables.dh.py') as r:
     benchmark_storage_uri_arg = root + '/deephaven-benchmark'
     benchmark_category_arg = 'release'  # release | nightly    

--- a/src/main/resources/io/deephaven/benchmark/run/profile/benchmark_snippet.dh.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/benchmark_snippet.dh.py
@@ -1,6 +1,6 @@
 from urllib.request import urlopen
 
-root = 'file:///data' if os.path.exists('/data/deephaven-benchmark') else 'https://storage.googleapis.com'
+root = 'file:///nfs' if os.path.exists('/nfs/deephaven-benchmark') else 'https://storage.googleapis.com'
 with urlopen(root + '/deephaven-benchmark/benchmark_tables.dh.py') as r:
     benchmark_storage_uri_arg = root + '/deephaven-benchmark'
     benchmark_category_arg = 'release'  # release | nightly    

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/nightly.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/nightly.py
@@ -6,7 +6,7 @@
 
 from urllib.request import urlopen
 
-root = 'file:///data' if os.path.exists('/data/deephaven-benchmark') else 'https://storage.googleapis.com'
+root = 'file:///nfs' if os.path.exists('/nfs/deephaven-benchmark') else 'https://storage.googleapis.com'
 with urlopen(root + '/deephaven-benchmark/benchmark_tables.dh.py') as r:
     benchmark_storage_uri_arg = root + '/deephaven-benchmark'
     benchmark_category_arg = 'nightly'  # release | nightly    

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/release.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/release.py
@@ -7,7 +7,7 @@
 
 from urllib.request import urlopen
 
-root = 'file:///data' if os.path.exists('/data/deephaven-benchmark') else 'https://storage.googleapis.com'
+root = 'file:///nfs' if os.path.exists('/nfs/deephaven-benchmark') else 'https://storage.googleapis.com'
 with urlopen(root + '/deephaven-benchmark/benchmark_tables.dh.py') as r:
     benchmark_storage_uri_arg = root + '/deephaven-benchmark'
     benchmark_category_arg = 'release'  # release | nightly    


### PR DESCRIPTION
- Added a Github workflow step to rsync GCloud to the Demo server.
- Updated query snippets to use **/nfs** instead of **/data**, since the Demo server uses /data for other things
- Worked with Chip and Danila to get access right

Part of Issue: https://github.com/deephaven/benchmark/issues/179
 