### PR TITLE
Added adhoc category for running benchmarks

### DIFF
--- a/.github/resources/adhoc-benchmark-docker-compose.yml
+++ b/.github/resources/adhoc-benchmark-docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.4"
+
+services:
+  deephaven:
+    image: ghcr.io/deephaven/server:edge
+    ports:
+      - "${DEEPHAVEN_PORT:-10000}:10000"
+    volumes:
+      - ./data:/data
+    environment:
+      - "START_OPTS=-Xmx24g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler"
+
+  redpanda:
+    command:
+    - redpanda
+    - start
+    - --smp 2
+    - --reserve-memory 0M
+    - --memory=1G
+    - --overprovisioned
+    - --node-id 0
+    - --check=false
+    - --kafka-addr
+    - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+    - --advertise-kafka-addr
+    - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
+    - --pandaproxy-addr 0.0.0.0:8082
+    - --advertise-pandaproxy-addr redpanda:8082
+    image: docker.redpanda.com/vectorized/redpanda:v22.2.5
+    ports:
+    - 8081:8081
+    - 8082:8082
+    - 9092:9092
+    - 29092:29092

--- a/.github/resources/adhoc-scale-benchmark.properties
+++ b/.github/resources/adhoc-scale-benchmark.properties
@@ -1,0 +1,42 @@
+
+# Deephaven engine address (same one the UI uses)
+deephaven.addr=localhost:10000
+
+# External java client address (Barrage Java Client)
+client.redpanda.addr=localhost:9092
+
+# External ReST schema registry supporting kafka (Kafka Producer)
+client.schema.registry.addr=localhost:8081
+
+# Internal ReST schema registry (Use in query scripts for kafka consume)
+schema.registry.addr=redpanda:8081
+
+# Internal kafka consumer address (Use in query scripts for kafka consume)
+kafka.consumer.addr=redpanda:29092
+
+# Default timeout to complete processes (Executing queries, generating records)
+default.completion.timeout=10 minutes
+
+# Slows down record generation (Used for experiments not full test runs)
+generator.pause.per.row=0 millis
+
+# Compression used for generating and storing records (SNAPPY, ZSTD, LZ4, LZO, GZIP, NONE) 
+record.compression=SNAPPY
+
+# Row count to scale tests (Tests can override but typically do not)
+scale.row.count=100000
+
+# True: Use a timestamp for the parent directory of each test run
+# False: Overwrite previous test results for each test run
+# Blank: Overwrite if JUnit launch, timestamp if Benchmark main launch
+timestamp.test.results=
+
+# Experimental: Docker compose file (e.g. /mypath/docker-compose.yml)
+# Empty means no docker restart attempt will be made
+docker.compose.file=/root/deephaven/docker-compose.yml
+
+# The url used for posting messages to slack
+slack.token=${slackToken}
+
+# The channel to post notifications to
+slack.channel=${slackChannel}

--- a/.github/scripts/run-benchmarks-remote.sh
+++ b/.github/scripts/run-benchmarks-remote.sh
@@ -17,8 +17,11 @@ HOST=`hostname`
 RUN_DIR=/root/run
 DEEPHAVEN_DIR=/root/deephaven
 
-# Match run type (nightly, release, compare) to benchmark test package
+# Match run type (nightly, release, compare, adhoc) to benchmark test package
 case ${RUN_TYPE} in
+  adhoc)
+    TEST_PACKAGE=io.deephaven.benchmark.tests.standard.aggby
+    ;;
   compare)
     TEST_PACKAGE=io.deephaven.benchmark.tests.compare
     ;;

--- a/.github/workflows/adhoc-remote-benchmarks.yml
+++ b/.github/workflows/adhoc-remote-benchmarks.yml
@@ -1,0 +1,19 @@
+# Run benchmarks on a remote system according to 
+# resources/release-benchmark-docker-compose.yml
+# - Calls the reusable worflow remote-benchmarks.yml
+# - Used for testing the full workflow without affecting 
+#   permanent data in other categoriees (like release, nightly)
+# - Produces temporary data that is not preserved long term 
+
+name: Adhoc Benchmark Test on Docker Deephaven
+
+on:
+  workflow_dispatch:
+    branches: [ "**" ]
+
+jobs:
+  process-release-benchmarks:
+    uses: ./.github/workflows/remote-benchmarks.yml
+    with:
+      run-type: adhoc
+    secrets: inherit


### PR DESCRIPTION
- Added adhoc category for the running benchmarks before checking in changes to the Github workflow, scripts, or benchmarks.  (Was using release for this and then cleaning up after.)
- Allows for running benchmarks exactly as release and nightly, even publishing to GCloud and Demo NFS server without overwriting existing data and having to restore later
- The data written to GCloud and Demo NFS server is entirely disposable