### PR TITLE
Updated the benchmark for update columns in the standard SVG

### DIFF
--- a/src/main/resources/io/deephaven/benchmark/run/profile/standard-benchmark-summary.template.svg
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/standard-benchmark-summary.template.svg
@@ -113,7 +113,7 @@
         </thead>
       	<tbody>
       	  <tr><td>Where with 2 Filters</td><td>${Where- 2 Filters -Static=>op_rate}</td><td>${Where- 2 Filters -Inc=>op_rate}</td></tr>
-      	  <tr><td>Update with 2 New Calculated Columns</td><td>${Update- 2 Calcs Using Int -Static=>op_rate}</td><td>${Update- 2 Calcs Using Int -Inc=>op_rate}</td></tr>
+      	  <tr><td>Update with 2 New Calculated Columns</td><td>${Update-Sum- 2 Calcs Using 2 Cols -Static=>op_rate}</td><td>${Update- 2 Calcs Using Int -Inc=>op_rate}</td></tr>
       	  <tr><td>Select Distinct on 1 Group of 250 Unique Values</td><td>${SelectDistinct- 1 Group 250 Unique Vals -Static=>op_rate}</td><td>${SelectDistinct- 1 Group 250 Unique Vals -Inc=>op_rate}</td></tr>
       	  <tr><td>Average by 2 Groups of 160K Unique Combos</td><td>${AvgBy- 2 Groups 160K Unique Combos Int -Static=>op_rate}</td><td>${AvgBy- 2 Groups 160K Unique Combos Int -Inc=>op_rate}</td></tr>
       	  <tr><td>Sort 2 Columns</td><td>${Sort- 2 Cols Default Order -Static=>op_rate}</td><td>${Sort- 2 Cols Default Order -Inc=>op_rate}</td></tr>


### PR DESCRIPTION
Recent improvements to the update/select/view/update_view formula tests renamed one benchmark in the SVG the appears in at the top of the Benchmark Readme. 
- Corrected the name in the SVG template that is used for both release and nightly summaries.