### PR TITLE
Re-scaled Where benchmarks after JVM 21 and recent improvements

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereInTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereInTest.java
@@ -28,14 +28,14 @@ public class WhereInTest {
 
     @Test
     public void whereIn1Filter() {
-        runner.setScaleFactors(300, 20);
+        runner.setScaleFactors(210, 150);
         var q = "source.where_in(where_filter, cols=['str250 = sPrefix'])";
         runner.test("WhereIn- 1 Filter Col", q, "str250", "int250");
     }
 
     @Test
     public void whereIn2Filter() {
-        runner.setScaleFactors(40, 5);
+        runner.setScaleFactors(85, 60);
         var q = "source.where_in(where_filter, cols=['str250 = sPrefix', 'str640 = sSuffix'])";
         runner.test("WhereIn- 2 Filter Cols", q, "str250", "str640", "int250");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereNotInTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereNotInTest.java
@@ -28,14 +28,14 @@ public class WhereNotInTest {
 
     @Test
     public void whereNotIn1Filter() {
-        runner.setScaleFactors(80, 10);
+        runner.setScaleFactors(90, 55);
         var q = "source.where_not_in(where_filter, cols=['str250 = sPrefix'])";
         runner.test("WhereNotIn- 1 Filter Col", q, "str250", "int250");
     }
 
     @Test
     public void whereNotIn2Filter() {
-        runner.setScaleFactors(50, 5);
+        runner.setScaleFactors(70, 60);
         var q = "source.where_not_in(where_filter, cols=['str250 = sPrefix', 'str640 = sSuffix'])";
         runner.test("WhereNotIn- 2 Filter Cols", q, "str250", "str640", "int250");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereTest.java
@@ -18,7 +18,7 @@ public class WhereTest {
 
     @Test
     public void where1Filter() {
-        runner.setScaleFactors(300, 15);
+        runner.setScaleFactors(260, 170);
         var q = """
         source.where(filters=["str250 = '250'"]);
         """;
@@ -27,7 +27,7 @@ public class WhereTest {
     
     @Test
     public void where2Filters() {
-        runner.setScaleFactors(200, 20);
+        runner.setScaleFactors(210, 170);
         var q = """
         source.where(filters=["str250 = '250'", "str640 = '640'"]);
         """;
@@ -36,7 +36,7 @@ public class WhereTest {
     
     @Test
     public void whereFilterInList() {
-        runner.setScaleFactors(200, 20);
+        runner.setScaleFactors(190, 160);
         var q = """
         source.where(filters=["str250 in '250', '1', '249', '2', '248'"]);
         """;
@@ -45,7 +45,7 @@ public class WhereTest {
     
     @Test
     public void whereOneOf2Filters() {
-        runner.setScaleFactors(100, 7);
+        runner.setScaleFactors(80, 75);
         var q = """
         source.where_one_of(filters=["str250 = '250'", "str640 = '640'"]);
         """;


### PR DESCRIPTION
The where benchmarks are some of the worst offenders when it comes to variability.  Re-scaled those benchmarks for two reasons
- The performance fix to WhereIn and WhereNotIn
- The inclusion of JVM 21 changed performance characteristics

