### PR TITLE
Fixed type casting issue for Python breaking change

### DIFF
--- a/src/main/resources/io/deephaven/benchmark/run/profile/benchmark_tables.dh.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/benchmark_tables.dh.py
@@ -136,17 +136,17 @@ add_metric_value_diff('GarbageCollectorExtImpl', 'G1 Old Generation', 'Collectio
 add_metric_value_diff('GarbageCollectorExtImpl', 'G1 Old Generation', 'CollectionTime', 'g1_old_collect_time')
 
 import statistics
-def rstd(rates):
+def rstd(rates) -> float:
     rates = [i for i in rates if i >= 0]
     mean = statistics.mean(rates)
     return (statistics.pstdev(rates) * 100.0 / mean) if mean != 0 else 0.0
     
-def zscore(rate, rates):
+def zscore(rate, rates) -> float:
     rates = [i for i in rates if i >= 0]
     std = statistics.pstdev(rates)
     return ((rate - statistics.mean(rates)) / std) if std != 0 else 0.0
 
-def zprob(zscore):
+def zprob(zscore) -> float:
     lower = -abs(zscore)
     upper = abs(zscore)
     return 1 - (statistics.NormalDist().cdf(upper) - statistics.NormalDist().cdf(lower))
@@ -158,7 +158,7 @@ def rchange(rates) -> float:
     m = statistics.mean(rates[:-1])
     return (rates[-1] - m) / m * 100.0
 
-def gain(start:float, end:float) -> float:
+def gain(start, end) -> float:
     return (end - start) / start * 100.0
 
 def format_rates(rates):

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/nightly.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/nightly.py
@@ -31,11 +31,11 @@ def op_by_date_range(begin_millis, end_millis, op_prefix):
     ]).view([
         'Benchmark=benchmark_name', 'Start=timestamp[0]', 'End=timestamp[len(timestamp)-1]', 
         'Start_Rate=op_rate[0]', 'End_Rate=op_rate[len(op_rate)-1]',
-        'Rate_Change=(float)gain(Start_Rate, End_Rate)',
+        'Rate_Change=gain(Start_Rate, End_Rate)',
         'Start_Heap_Used=(long)heap_used[0]', 'End_Heap_Used=(long)heap_used[len(heap_used)-1]',
-        'Heap_Used_Change=(float)gain(Start_Heap_Used, End_Heap_Used)',
+        'Heap_Used_Change=gain(Start_Heap_Used, End_Heap_Used)',
         'Start_NonHeap_Used=(long)non_heap_used[0]', 'End_NonHeap_Used=(long)non_heap_used[len(non_heap_used)-1]',
-        'NonHeap_Used_Change=(float)gain(Start_NonHeap_Used, End_NonHeap_Used)'
+        'NonHeap_Used_Change=gain(Start_NonHeap_Used, End_NonHeap_Used)'
     ]).where([
         '!Benchmark.contains(`Rows Per`)'
     ])

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/release.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/release.py
@@ -51,7 +51,7 @@ past_static_rates = newest_benchmarks.where([
 ]).update([
     'op_group_rates=vec(reverse(op_group_rates)).subVector(0, versLen)',
     'op_group_versions=vecObj(reverseObj(op_group_versions)).subVector(0, versLen)',
-    'Change=(float)gain(op_group_rates[1], op_group_rates[0])'
+    'Change=gain(op_group_rates[1], op_group_rates[0])'
 ]).update([
     (vers[i] + "=op_group_rates[" + str(i) + "]") for i in range(versLen)
 ]).view([


### PR DESCRIPTION
Some recent python changes introduced a breaking change for type casting.  Casting from Java to Python in queries is now more strict but also includes respect for Python UDF return types.

For standard Queries (like for nightly worst in slack:
- Removed all Python UDF function param types
- Added return type hints where applicable
- Removed unnecessary float casts from queries
- Note: For backward compatibility the benchmark_tables.dh.py tables still have the extraneous float casts in queries