### PR TITLE
Improve datetimeutils benchmark tests

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -136,13 +136,13 @@ public class StandardTestRunner {
      * @param loadColumns columns to load from the generated parquet file
      */
     public void test(String name, long expectedRowCount, String operation, String... loadColumns) {
-        var read = getReadOperation(staticFactor);
+        var read = getReadOperation(staticFactor, loadColumns);
         var result = runStaticTest(name, operation, read, loadColumns);
         var rcount = result.resultRowCount();
         var ecount = getExpectedRowCount(expectedRowCount, staticFactor);
         assertTrue(rcount > 0 && rcount <= ecount, "Wrong result Static row count: " + rcount);
 
-        read = getReadOperation(incFactor);
+        read = getReadOperation(incFactor, loadColumns);
         result = runIncTest(name, operation, read, loadColumns);
         rcount = result.resultRowCount();
         ecount = getExpectedRowCount(expectedRowCount, incFactor);

--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -153,8 +153,9 @@ public class StandardTestRunner {
         return (expectedRowCount < 1) ? Long.MAX_VALUE : expectedRowCount;
     }
 
-    String getReadOperation(int scaleFactor) {
+    String getReadOperation(int scaleFactor, String... loadColumns) {
         var read = "read('/data/${mainTable}.parquet').select(formulas=[${loadColumns}])";
+        read = (loadColumns.length == 0) ? ("empty_table(" + scaleRowCount + ")") : read;
 
         if (scaleFactor > 1) {
             read = "merge([${readTable}] * ${scaleFactor})".replace("${readTable}", read);
@@ -267,7 +268,7 @@ public class StandardTestRunner {
     Bench initialize(Object testInst) {
         var query = """
         import time
-        from deephaven import new_table, garbage_collect, merge
+        from deephaven import new_table, empty_table, garbage_collect, merge 
         from deephaven.column import long_col, double_col
         from deephaven.parquet import read
         """;

--- a/src/it/java/io/deephaven/benchmark/tests/standard/formula/DateTimeFormulaTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/formula/DateTimeFormulaTest.java
@@ -13,44 +13,43 @@ public class DateTimeFormulaTest {
 
     @Test
     public void now() {
-        setup(6, 35, 15);
+        setup(50, 4, 2);
         var q = "source.update(formulas=['New1 = now()'])";
-        runner.test("Now- now()", q, "int250");
+        runner.test("Now- now()", q);
     }
 
     @Test
     public void parseInstant() {
         setup(1, 1, 1);
         var q = "source.update(formulas=['New1 = parseInstant(`2023-05-31T04:52:14.001 ET`)'])";
-        runner.test("ParseInstant- DateTime String with Timezone", q, "int250");
+        runner.test("ParseInstant- DateTime String with Timezone", q);
     }
 
     @Test
     public void parseDuration() {
-        setup(2, 9, 1);
+        setup(3, 6, 1);
         var q = "source.update(formulas=['New1 = parseDuration(`PT4H52M14S`)'])";
-        runner.test("ParseDuration- PT Duration String", q, "int250");
+        runner.test("ParseDuration- PT Duration String", q);
     }
 
     @Test
     public void parseLocalTime() {
-        setup(2, 7, 1);
+        setup(3, 5, 1);
         var q = "source.update(formulas=['New1 = parseLocalTime(`04:52:14.001`)'])";
-        runner.test("ParseLocalTime- Time String)", q, "int250");
+        runner.test("ParseLocalTime- Time String", q);
     }
 
     @Test
     public void epochNanosToZonedDateTime() {
-        setup(2, 11, 10);
+        setup(24, 1, 1);
         var q = """
         source.update(formulas=['New1=epochNanosToZonedDateTime(1697240421926014741L,java.time.ZoneOffset.UTC)'])
         """;
-        runner.test("EpochNanosToZonedDateTime- Nanos Long and ZoneId", q, "int250");
+        runner.test("EpochNanosToZonedDateTime- Nanos Long and ZoneId", q);
     }
 
     private void setup(int rowFactor, int staticFactor, int incFactor) {
         runner.setRowFactor(rowFactor);
-        runner.tables("source");
         runner.setScaleFactors(staticFactor, incFactor);
     }
 


### PR DESCRIPTION
- Added empty_table feature to StandardTestRunner
- Reworked the DateTimeFormulasTest to avoid the unnecessary parquet use
- Re-scaled the tests