### PR TITLE
Add logging to kafka and file test runners

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -231,16 +231,14 @@ final public class StandardTestRunner {
         if (api.isClosed())
             initialize(testInst);
         api.setName(name);
-        var logBeginMarker = getLogSnippet("Begin", name);
-        var logEndMarker = getLogSnippet("End", name);
         query = query.replace("${readTable}", read);
         query = query.replace("${mainTable}", mainTable);
         query = query.replace("${loadSupportTables}", loadSupportTables());
         query = query.replace("${loadColumns}", listStr(loadColumns));
         query = query.replace("${setupQueries}", String.join("\n", setupQueries));
         query = query.replace("${operation}", operation);
-        query = query.replace("${logOperationBegin}", logBeginMarker);
-        query = query.replace("${logOperationEnd}", logEndMarker);
+        query = query.replace("${logOperationBegin}", getLogSnippet("Begin", name));
+        query = query.replace("${logOperationEnd}", getLogSnippet("End", name));
 
         try {
             var result = new AtomicReference<Result>();
@@ -261,7 +259,7 @@ final public class StandardTestRunner {
             api.result().test("deephaven-engine", result.get().elapsedTime(), result.get().loadedRowCount());
             return result.get();
         } finally {
-            addDockerLog(api, logBeginMarker, logEndMarker);
+            addDockerLog(api);
             api.close();
         }
     }
@@ -296,7 +294,7 @@ final public class StandardTestRunner {
         api.query(query).execute();
     }
 
-    void addDockerLog(Bench api, String beginMarker, String endMarker) {
+    void addDockerLog(Bench api) {
         var timer = api.timer();
         var logText = controller.getLog();
         if (logText.isBlank())

--- a/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaBlinkHeapTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaBlinkHeapTest.java
@@ -14,7 +14,7 @@ public class KafkaBlinkHeapTest {
     final int colCount = 20;
 
     @Test
-    public void CountBy1gHeapFromKafkaAvroBlink() {
+    void CountBy1gHeapFromKafkaAvroBlink() {
         runner.api.setName("CountBy- 20 Cols 1g Heap Avro Blink");
         runner.restartWithHeap(1);
         runner.table(rowCount / 2, colCount, "long", "avro");
@@ -22,7 +22,7 @@ public class KafkaBlinkHeapTest {
     }
 
     @Test
-    public void CountBy1gHeapFromKafkaJsonBlink() {
+    void CountBy1gHeapFromKafkaJsonBlink() {
         runner.api.setName("CountBy- 20 Cols 1g Heap JSON Blink");
         runner.restartWithHeap(1);
         runner.table(rowCount / 4, colCount, "long", "json");
@@ -30,7 +30,7 @@ public class KafkaBlinkHeapTest {
     }
 
     @Test
-    public void CountBy10gHeapFromKafkaAvroBlink() {
+    void CountBy10gHeapFromKafkaAvroBlink() {
         runner.api.setName("CountBy- 20 Cols 10g Heap Avro Blink");
         runner.restartWithHeap(10);
         runner.table(rowCount / 2, colCount, "long", "avro");
@@ -38,7 +38,7 @@ public class KafkaBlinkHeapTest {
     }
 
     @Test
-    public void CountBy10gHeapFromKafkaJsonBlink() {
+    void CountBy10gHeapFromKafkaJsonBlink() {
         runner.api.setName("CountBy- 20 Cols 10g Heap JSON Blink");
         runner.restartWithHeap(10);
         runner.table(rowCount / 4, colCount, "long", "json");
@@ -46,7 +46,7 @@ public class KafkaBlinkHeapTest {
     }
 
     @AfterEach
-    public void teardown() {
+    void teardown() {
         runner.api.close();
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaBlinkWidthTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaBlinkWidthTest.java
@@ -12,7 +12,7 @@ public class KafkaBlinkWidthTest {
     final long rowCount = runner.api.propertyAsIntegral("scale.row.count", "100000");
 
     @Test
-    public void CountBy10ColsFromKafkaAvroBlink() {
+    void CountBy10ColsFromKafkaAvroBlink() {
         runner.api.setName("CountBy- 10 Cols Wide Avro Blink");
         runner.restartWithHeap(10);
         runner.table(rowCount, 10, "long", "avro");
@@ -20,7 +20,7 @@ public class KafkaBlinkWidthTest {
     }
 
     @Test
-    public void CountBy10ColsFromKafkaJsonBlink() {
+    void CountBy10ColsFromKafkaJsonBlink() {
         runner.api.setName("CountBy- 10 Cols Wide JSON Blink");
         runner.restartWithHeap(10);
         runner.table(rowCount, 10, "long", "json");
@@ -28,7 +28,7 @@ public class KafkaBlinkWidthTest {
     }
     
     @Test
-    public void CountBy100ColsFromKafkaAvroBlink() {
+    void CountBy100ColsFromKafkaAvroBlink() {
         runner.api.setName("CountBy- 100 Cols Wide Avro Blink");
         runner.restartWithHeap(10);
         runner.table(rowCount / 3, 100, "long", "avro");
@@ -36,7 +36,7 @@ public class KafkaBlinkWidthTest {
     }
 
     @Test
-    public void CountBy100ColsFromKafkaJsonBlink() {
+    void CountBy100ColsFromKafkaJsonBlink() {
         runner.api.setName("CountBy- 100 Cols Wide JSON Blink");
         runner.restartWithHeap(10);
         runner.table(rowCount / 10, 100, "long", "json");
@@ -44,7 +44,7 @@ public class KafkaBlinkWidthTest {
     }
     
     @Test
-    public void CountBy1000ColsFromKafkaAvroBlink() {
+    void CountBy1000ColsFromKafkaAvroBlink() {
         runner.api.setName("CountBy- 1000 Cols Wide Avro Blink");
         runner.restartWithHeap(10);
         runner.table(rowCount / 25, 1000, "long", "avro");
@@ -52,7 +52,7 @@ public class KafkaBlinkWidthTest {
     }
 
     @Test
-    public void CountBy1000ColsgFromKafkaJsonBlink() {
+    void CountBy1000ColsgFromKafkaJsonBlink() {
         runner.api.setName("CountBy- 1000 Cols Wide JSON Blink");
         runner.restartWithHeap(10);
         runner.table(rowCount / 100, 1000, "long", "json");
@@ -60,7 +60,7 @@ public class KafkaBlinkWidthTest {
     }
 
     @AfterEach
-    public void teardown() {
+    void teardown() {
         runner.api.close();
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaDataTypeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaDataTypeTest.java
@@ -13,7 +13,7 @@ public class KafkaDataTypeTest {
     final int colCount = 20;
 
     @Test
-    public void NoOp20LongColsFromKafkaAvroAppend() {
+    void NoOp20LongColsFromKafkaAvroAppend() {
         runner.api.setName("NoOp- 20 Long Cols Avro Append");
         runner.restartWithHeap(10);
         runner.table(rowCount, colCount, "long", "avro");
@@ -21,7 +21,7 @@ public class KafkaDataTypeTest {
     }
 
     @Test
-    public void NoOp20LongColsFromKafkaJsonAppend() {
+    void NoOp20LongColsFromKafkaJsonAppend() {
         runner.api.setName("NoOp- 20 Long Cols JSON Append");
         runner.restartWithHeap(10);
         runner.table(rowCount / 2, colCount, "long", "json");
@@ -29,7 +29,7 @@ public class KafkaDataTypeTest {
     }
     
     @Test
-    public void NoOp20DoubleColsFromKafkaAvroAppend() {
+    void NoOp20DoubleColsFromKafkaAvroAppend() {
         runner.api.setName("NoOp- 20 Double Cols Avro Append");
         runner.restartWithHeap(10);
         runner.table(rowCount, colCount, "double", "avro");
@@ -37,7 +37,7 @@ public class KafkaDataTypeTest {
     }
 
     @Test
-    public void NoOpDoubleColsFromKafkaJsonAppend() {
+    void NoOpDoubleColsFromKafkaJsonAppend() {
         runner.api.setName("NoOp- 20 Double Cols JSON Append");
         runner.restartWithHeap(10);
         runner.table(rowCount / 4, colCount, "double", "json");
@@ -45,7 +45,7 @@ public class KafkaDataTypeTest {
     }
     
     @Test
-    public void NoOp20DateTimeColsFromKafkaAvroAppend() {
+    void NoOp20DateTimeColsFromKafkaAvroAppend() {
         runner.api.setName("NoOp- 20 DateTime Cols Avro Append");
         runner.restartWithHeap(10);
         runner.table(rowCount, colCount, "timestamp-millis", "avro");
@@ -53,7 +53,7 @@ public class KafkaDataTypeTest {
     }
 
     @Test
-    public void NoOp20DateTimeColsFromKafkaJsonAppend() {
+    void NoOp20DateTimeColsFromKafkaJsonAppend() {
         runner.api.setName("NoOp- 20 DateTime Cols JSON Append");
         runner.restartWithHeap(10);
         runner.table(rowCount / 2, colCount, "timestamp-millis", "json");
@@ -61,7 +61,7 @@ public class KafkaDataTypeTest {
     }
 
     @AfterEach
-    public void teardown() {
+    void teardown() {
         runner.api.close();
     }
 


### PR DESCRIPTION
Added log collection to KafkaTestRunner and FileTestRunner.  Because of the nature of the Kafka and CSV tests, adding an operational marker like in StandardTestRunner is not necessary.