### PR TITLE
Bumped redpanda to 23.2.22

### DIFF
--- a/.github/resources/adhoc-benchmark-docker-compose.yml
+++ b/.github/resources/adhoc-benchmark-docker-compose.yml
@@ -26,7 +26,7 @@ services:
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     - --pandaproxy-addr 0.0.0.0:8082
     - --advertise-pandaproxy-addr redpanda:8082
-    image: docker.redpanda.com/vectorized/redpanda:v22.2.5
+    image: docker.redpanda.com/vectorized/redpanda:v23.2.22
     ports:
     - 8081:8081
     - 8082:8082

--- a/.github/resources/compare-benchmark-docker-compose.yml
+++ b/.github/resources/compare-benchmark-docker-compose.yml
@@ -26,7 +26,7 @@ services:
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     - --pandaproxy-addr 0.0.0.0:8082
     - --advertise-pandaproxy-addr redpanda:8082
-    image: docker.redpanda.com/vectorized/redpanda:v22.2.5
+    image: docker.redpanda.com/vectorized/redpanda:v23.2.22
     ports:
     - 8081:8081
     - 8082:8082

--- a/.github/resources/integration-docker-compose.yml
+++ b/.github/resources/integration-docker-compose.yml
@@ -26,7 +26,7 @@ services:
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     - --pandaproxy-addr 0.0.0.0:8082
     - --advertise-pandaproxy-addr redpanda:8082
-    image: docker.redpanda.com/vectorized/redpanda:v22.2.5
+    image: docker.redpanda.com/vectorized/redpanda:v23.2.22
     ports:
     - 8081:8081
     - 8082:8082

--- a/.github/resources/nightly-benchmark-docker-compose.yml
+++ b/.github/resources/nightly-benchmark-docker-compose.yml
@@ -26,7 +26,7 @@ services:
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     - --pandaproxy-addr 0.0.0.0:8082
     - --advertise-pandaproxy-addr redpanda:8082
-    image: docker.redpanda.com/vectorized/redpanda:v22.2.5
+    image: docker.redpanda.com/vectorized/redpanda:v23.2.22
     ports:
     - 8081:8081
     - 8082:8082

--- a/.github/resources/release-benchmark-docker-compose.yml
+++ b/.github/resources/release-benchmark-docker-compose.yml
@@ -26,7 +26,7 @@ services:
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     - --pandaproxy-addr 0.0.0.0:8082
     - --advertise-pandaproxy-addr redpanda:8082
-    image: docker.redpanda.com/vectorized/redpanda:v22.2.5
+    image: docker.redpanda.com/vectorized/redpanda:v23.2.22
     ports:
     - 8081:8081
     - 8082:8082


### PR DESCRIPTION
- Updated _docker-compose.yml_ files in all benchmark workflows to use Redpanda version 23.2.22,
- Tested locally and with adhoc workflow
- Tested locally with new Kafka protobuf tests (not merged yet)