### PR TITLE
Updateby refactor

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumComboTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumComboTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class CumComboTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(5);
         runner.tables("timed");
         
         setupStr = """
@@ -30,7 +30,8 @@ public class CumComboTest {
     }
 
     @Test
-    public void cumComboNoGroups6Ops() {
+    public void cumComboNoGroups6Op0s() {
+        runner.setScaleFactors(6, 3);
         runner.addSetupQuery(operations("int5"));
         var q = "timed.update_by(ops=[ema_tick_op, ema_time_op, max_op, min_op, sum_op, prod_op])";
         runner.test("CumCombo- 6 Ops No Groups", q, "int5", "timestamp");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMaxTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMaxTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -20,7 +20,7 @@ public class CumMaxTest {
 
     @Test
     public void cumMax0Group1Col() {
-        runner.setScaleFactors(50, 20);
+        runner.setScaleFactors(40, 20);
         var q = "timed.update_by(ops=cum_max(cols=['X=int5']))";
         runner.test("CumMax- No Groups 1 Col", q, "int5");
     }
@@ -34,7 +34,7 @@ public class CumMaxTest {
 
     @Test
     public void cumMax1Group1Col() {
-        runner.setScaleFactors(9, 1);
+        runner.setScaleFactors(7, 1);
         var q = "timed.update_by(ops=cum_max(cols=['X=int5']), by=['str100'])";
         runner.test("CumMax- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5");
     }
@@ -48,14 +48,14 @@ public class CumMaxTest {
 
     @Test
     public void cumMax2GroupsInt() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=cum_max(cols=['X=int5']), by=['str100','str150'])";
         runner.test("CumMax- 2 Groups 15K Unique Combos 1 Col Int",  q, "str100", "str150", "int5");
     }
     
     @Test
     public void cumMax2GroupsFloat() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=cum_max(cols=['X=float5']), by=['str100','str150'])";
         runner.test("CumMax- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150", "float5");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMinTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumMinTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -20,7 +20,7 @@ public class CumMinTest {
 
     @Test
     public void cumMin0Group1Col() {
-        runner.setScaleFactors(50, 20);
+        runner.setScaleFactors(40, 20);
         var q = "timed.update_by(ops=cum_min(cols=['X=int5']))";
         runner.test("CumMin- No Groups 1 Cols", q, "int5");
     }
@@ -34,7 +34,7 @@ public class CumMinTest {
 
     @Test
     public void cumMin1Group1Cols() {
-        runner.setScaleFactors(9, 1);
+        runner.setScaleFactors(7, 1);
         var q = "timed.update_by(ops=cum_min(cols=['X=int5']), by=['str100'])";
         runner.test("CumMin- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5");
     }
@@ -48,7 +48,7 @@ public class CumMinTest {
 
     @Test
     public void cumMin2GroupsInt() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=cum_min(cols=['X=int5']), by=['str100','str150'])";
         runner.test("CumMin- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5");
@@ -56,7 +56,7 @@ public class CumMinTest {
 
     @Test
     public void cumMin2GroupsFloat() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=cum_min(cols=['X=float5']), by=['str100','str150'])";
         runner.test("CumMin- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150", "float5");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumProdTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumProdTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -41,21 +41,21 @@ public class CumProdTest {
 
     @Test
     public void cumProd1Group2Cols() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(4, 1);
         var q = "timed.update_by(ops=cum_prod(cols=['X=int5','Y=int10']), by=['str100'])";
         runner.test("CumProd- 1 Group 100 Unique Vals 2 Cols", q, "str100", "int5", "int10");
     }
 
     @Test
     public void cumProd2GroupsInt() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=cum_prod(cols=['X=int5']), by=['str100','str150'])";
         runner.test("CumProd- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150", "int5");
     }
     
     @Test
     public void cumProd2GroupsFloat() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=cum_prod(cols=['X=float5']), by=['str100','str150'])";
         runner.test("CumProd- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150", "float5");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumSumTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/CumSumTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -34,28 +34,28 @@ public class CumSumTest {
 
     @Test
     public void cumSum1Group1Col() {
-        runner.setScaleFactors(9, 1);
+        runner.setScaleFactors(6, 1);
         var q = "timed.update_by(ops=cum_sum(cols=['X=int5']), by=['str100'])";
         runner.test("CumSum- 1 Group 100 Unique Vals 1 Cols", q, "str100", "int5");
     }
 
     @Test
     public void cumSum1Group2Cols() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(4, 1);
         var q = "timed.update_by(ops=cum_sum(cols=['X=int5','Y=int10']), by=['str100'])";
         runner.test("CumSum- 1 Group 100 Unique Vals 2 Cols", q, "str100", "int5", "int10");
     }
 
     @Test
     public void cumSum2GroupsInt() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=cum_sum(cols=['X=int5']), by=['str100','str150'])";
         runner.test("CumSum- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150", "int5");
     }
     
     @Test
     public void cumSum2GroupsFloat() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=cum_sum(cols=['X=float5']), by=['str100','str150'])";
         runner.test("CumSum- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150", "float5");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -20,14 +20,14 @@ public class EmMaxTickTest {
 
     @Test
     public void emMaxTick0Group1Col() {
-        runner.setScaleFactors(20, 12);
+        runner.setScaleFactors(15, 12);
         var q = "timed.update_by(ops=emmax_tick(decay_ticks=100,cols=['X=int5']))";
         runner.test("EmMaxTick- No Groups 1 Col", q, "int5");
     }
 
     @Test
     public void emMaxTick0Group2Cols() {
-        runner.setScaleFactors(10, 7);
+        runner.setScaleFactors(9, 6);
         var q = "timed.update_by(ops=emmax_tick(decay_ticks=100,cols=['X=int5','Y=int10']))";
         runner.test("EmMaxTick- No Groups 2 Cols", q, "int5", "int10");
     }
@@ -42,14 +42,14 @@ public class EmMaxTickTest {
 
     @Test
     public void emMaxTick1Group2Cols() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(3, 1);
         var q = "timed.update_by(ops=emmax_tick(decay_ticks=100,cols=['X=int5','Y=int10']), by=['str100'])";
         runner.test("EmMaxTick- 1 Group 100 Unique Vals 2 Cols", q, "str100", "int5", "int10");
     }
 
     @Test
     public void emMaxTick2GroupsInt() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=emmax_tick(decay_ticks=100,cols=['X=int5']), by=['str100','str150'])";
         runner.test("EmMaxTick- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5");
@@ -57,7 +57,7 @@ public class EmMaxTickTest {
 
     @Test
     public void emMaxTick2GroupsFloat() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=emmax_tick(decay_ticks=100,cols=['X=float5']), by=['str100','str150'])";
         runner.test("EmMaxTick- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
                 "float5");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -20,18 +20,21 @@ public class EmMaxTimeTest {
 
     @Test
     public void emMaxTime0Group1Col() {
+        runner.setScaleFactors(11, 8);
         var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']))";
         runner.test("EmMaxTime- No Groups 1 Col", q, "int5", "timestamp");
     }
 
     @Test
     public void emMaxTime1Group1Col() {
+        runner.setScaleFactors(5, 1);
         var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100'])";
         runner.test("EmMaxTime- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void emMaxTime2GroupsInt() {
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100','str150'])";
         runner.test("EmMaxTime- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5", "timestamp");
@@ -39,6 +42,7 @@ public class EmMaxTimeTest {
 
     @Test
     public void emMaxTime2GroupsFloat() {
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=emmax_time(ts_col='timestamp', decay_time='PT2S', cols=['X=float5']), by=['str100','str150'])";
         runner.test("EmMaxTime- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
                 "float5", "timestamp");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -20,35 +20,35 @@ public class EmMinTickTest {
 
     @Test
     public void emMinTick0Group1Col() {
-        runner.setScaleFactors(20, 12);
+        runner.setScaleFactors(4, 3);
         var q = "timed.update_by(ops=emmin_tick(decay_ticks=100,cols=['X=int5']))";
         runner.test("EmMinTick- No Groups 1 Col", q, "int5");
     }
 
     @Test
     public void emMinTick0Group2Cols() {
-        runner.setScaleFactors(10, 7);
+        runner.setScaleFactors(2, 2);
         var q = "timed.update_by(ops=emmin_tick(decay_ticks=100,cols=['X=int5','Y=int10']))";
         runner.test("EmMinTick- No Groups 2 Cols", q, "int5", "int10");
     }
 
     @Test
     public void emMinTick1Group1Col() {
-        runner.setScaleFactors(7, 1);
+        runner.setScaleFactors(5, 1);
         var q = "timed.update_by(ops=emmin_tick(decay_ticks=100,cols=['X=int5']), by=['str100'])";
         runner.test("EmMinTick- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5");
     }
 
     @Test
     public void emMinTick1Group2Cols() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(4, 1);
         var q = "timed.update_by(ops=emmin_tick(decay_ticks=100,cols=['X=int5','Y=int10']), by=['str100'])";
         runner.test("EmMinTick- 1 Group 100 Unique Vals 2 Cols", q, "str100", "int5", "int10");
     }
 
     @Test
     public void emMinTick2GroupsInt() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=emmin_tick(decay_ticks=100,cols=['X=int5']), by=['str100','str150'])";
         runner.test("EmMinTick- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5");
@@ -56,7 +56,7 @@ public class EmMinTickTest {
 
     @Test
     public void emMinTick2GroupsFloat() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=emmin_tick(decay_ticks=100,cols=['X=float5']), by=['str100','str150'])";
         runner.test("EmMinTick- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
                 "float5");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -20,18 +20,21 @@ public class EmMinTimeTest {
 
     @Test
     public void emMinTime0Group1Col() {
+        runner.setScaleFactors(3, 3);
         var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']))";
         runner.test("EmMinTime- No Groups 1 Col", q, "int5", "timestamp");
     }
 
     @Test
     public void emMinTime1Group1Col() {
+        runner.setScaleFactors(4, 1);
         var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100'])";
         runner.test("EmMinTime- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void emMinTime2GroupsInt() {
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100','str150'])";
         runner.test("EmMinTime- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5", "timestamp");
@@ -39,6 +42,7 @@ public class EmMinTimeTest {
 
     @Test
     public void emMinTime2GroupsFloat() {
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=emmin_time(ts_col='timestamp', decay_time='PT2S', cols=['X=float5']), by=['str100','str150'])";
         runner.test("EmMinTime- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
                 "float5", "timestamp");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmStdTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmStdTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -41,14 +41,14 @@ public class EmStdTickTest {
 
     @Test
     public void emStdTick1Group2Cols() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(4, 1);
         var q = "timed.update_by(ops=emstd_tick(decay_ticks=100,cols=['X=int5','Y=int10']), by=['str100'])";
         runner.test("EmStdTick- 1 Group 100 Unique Vals 2 Cols", q, "str100", "int5", "int10");
     }
 
     @Test
     public void emStdTick2GroupsInt() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=emstd_tick(decay_ticks=100,cols=['X=int5']), by=['str100','str150'])";
         runner.test("EmStdTick- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5");
@@ -56,7 +56,7 @@ public class EmStdTickTest {
 
     @Test
     public void emStdTick2GroupsFloat() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=emstd_tick(decay_ticks=100,cols=['X=float5']), by=['str100','str150'])";
         runner.test("EmStdTick- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
                 "float5");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmStdTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmStdTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -20,18 +20,21 @@ public class EmStdTimeTest {
 
     @Test
     public void emStdTime0Group1Col() {
+        runner.setScaleFactors(11, 6);
         var q = "timed.update_by(ops=emstd_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']))";
         runner.test("EmStdTime- No Groups 1 Col", q, "int5", "timestamp");
     }
 
     @Test
     public void emStdTime1Group1Col() {
+        runner.setScaleFactors(5, 1);
         var q = "timed.update_by(ops=emstd_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100'])";
         runner.test("EmStdTime- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void emStdTime2GroupsInt() {
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=emstd_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100','str150'])";
         runner.test("EmStdTime- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5", "timestamp");
@@ -39,6 +42,7 @@ public class EmStdTimeTest {
 
     @Test
     public void emStdTime2GroupsFloat() {
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=emstd_time(ts_col='timestamp', decay_time='PT2S', cols=['X=float5']), by=['str100','str150'])";
         runner.test("EmStdTime- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
                 "float5", "timestamp");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -20,21 +20,21 @@ public class EmaTickTest {
 
     @Test
     public void emaTick0Group1Col() {
-        runner.setScaleFactors(30, 15);
+        runner.setScaleFactors(25, 15);
         var q = "timed.update_by(ops=ema_tick(decay_ticks=100,cols=['X=int5']))";
         runner.test("EmaTick- No Groups 1 Col", q, "int5");
     }
 
     @Test
     public void emaTick0Group2Cols() {
-        runner.setScaleFactors(15, 8);
+        runner.setScaleFactors(12, 8);
         var q = "timed.update_by(ops=ema_tick(decay_ticks=100,cols=['X=int5','Y=int10']))";
         runner.test("EmaTick- No Groups 2 Cols", q, "int5", "int10");
     }
 
     @Test
     public void emaTick1Group1Col() {
-        runner.setScaleFactors(9, 1);
+        runner.setScaleFactors(6, 1);
         var q = "timed.update_by(ops=ema_tick(decay_ticks=100,cols=['X=int5']), by=['str100'])";
         runner.test("EmaTick- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5");
     }
@@ -48,7 +48,7 @@ public class EmaTickTest {
 
     @Test
     public void emaTick2GroupsInt() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=ema_tick(decay_ticks=100,cols=['X=int5']), by=['str100','str150'])";
         runner.test("EmaTick- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5");
@@ -56,7 +56,7 @@ public class EmaTickTest {
 
     @Test
     public void emaTick2GroupsFloat() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=ema_tick(decay_ticks=100,cols=['X=float5']), by=['str100','str150'])";
         runner.test("EmaTick- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
                 "float5");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmaTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -20,18 +20,21 @@ public class EmaTimeTest {
 
     @Test
     public void emaTime0Group1Col() {
+        runner.setScaleFactors(11, 9);
         var q = "timed.update_by(ops=ema_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']))";
         runner.test("EmaTime- No Groups 1 Col", q, "int5", "timestamp");
     }
 
     @Test
     public void emaTime1Group1Col() {
+        runner.setScaleFactors(5, 1);
         var q = "timed.update_by(ops=ema_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100'])";
         runner.test("EmaTime- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void emaTime2GroupsInt() {
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=ema_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100','str150'])";
         runner.test("EmaTime- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5", "timestamp");
@@ -39,6 +42,7 @@ public class EmaTimeTest {
     
     @Test
     public void emaTime2GroupsFloat() {
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=ema_time(ts_col='timestamp', decay_time='PT2S', cols=['X=float5']), by=['str100','str150'])";
         runner.test("EmaTime- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
                 "float5", "timestamp");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -20,21 +20,21 @@ public class EmsTickTest {
 
     @Test
     public void emsTick0Group1Col() {
-        runner.setScaleFactors(30, 15);
+        runner.setScaleFactors(25, 15);
         var q = "timed.update_by(ops=ems_tick(decay_ticks=100,cols=['X=int5']))";
         runner.test("EmsTick- No Groups 1 Col", q, "int5");
     }
 
     @Test
     public void emsTick0Group2Cols() {
-        runner.setScaleFactors(15, 8);
+        runner.setScaleFactors(12, 8);
         var q = "timed.update_by(ops=ems_tick(decay_ticks=100,cols=['X=int5','Y=int10']))";
         runner.test("EmsTick- No Groups 2 Cols", q, "int5", "int10");
     }
 
     @Test
     public void emsTick1Group1Col() {
-        runner.setScaleFactors(9, 1);
+        runner.setScaleFactors(7, 1);
         var q = "timed.update_by(ops=ems_tick(decay_ticks=100,cols=['X=int5']), by=['str100'])";
         runner.test("EmsTick- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5");
     }
@@ -48,7 +48,7 @@ public class EmsTickTest {
 
     @Test
     public void emsTick2GroupsInt() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=ems_tick(decay_ticks=100,cols=['X=int5']), by=['str100','str150'])";
         runner.test("EmsTick- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
                 "int5");
@@ -56,7 +56,7 @@ public class EmsTickTest {
 
     @Test
     public void emsTick2GroupsFloat() {
-        runner.setScaleFactors(5, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=ems_tick(decay_ticks=100,cols=['X=float5']), by=['str100','str150'])";
         runner.test("EmsTick- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
                 "float5");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -20,28 +20,30 @@ public class EmsTimeTest {
 
     @Test
     public void emsTime0Group1Col() {
+        runner.setScaleFactors(11, 9);
         var q = "timed.update_by(ops=ems_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']))";
         runner.test("EmsTime- No Groups 1 Col", q, "int5", "timestamp");
     }
 
     @Test
     public void emsTime1Group1Col() {
+        runner.setScaleFactors(5, 1);
         var q = "timed.update_by(ops=ems_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100'])";
         runner.test("EmsTime- 1 Group 100 Unique Vals 1 Col", q, "str100", "int5", "timestamp");
     }
 
     @Test
     public void emsTime2GroupsInt() {
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=ems_time(ts_col='timestamp', decay_time='PT2S', cols=['X=int5']), by=['str100','str150'])";
-        runner.test("EmsTime- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150",
-                "int5", "timestamp");
+        runner.test("EmsTime- 2 Groups 15K Unique Combos 1 Col Int", q, "str100", "str150", "int5", "timestamp");
     }
-    
+
     @Test
     public void emsTime2GroupsFloat() {
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=ems_time(ts_col='timestamp', decay_time='PT2S', cols=['X=float5']), by=['str100','str150'])";
-        runner.test("EmsTime- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150",
-                "float5", "timestamp");
+        runner.test("EmsTime- 2 Groups 15K Unique Combos 1 Col Float", q, "str100", "str150", "float5", "timestamp");
     }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingAvgTickTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -27,7 +27,7 @@ public class RollingAvgTickTest {
 
     @Test
     public void rollingAvgTick0Group3Ops() {
-        runner.setScaleFactors(4,4);
+        runner.setScaleFactors(4, 4);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingAvgTick- 3 Ops No Groups",  q, "int5");
     }
@@ -41,7 +41,7 @@ public class RollingAvgTickTest {
 
     @Test
     public void rollingAvgTime2Groups3OpsInt() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
         runner.test("RollingAvgTick- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
                 "int5");
@@ -49,7 +49,7 @@ public class RollingAvgTickTest {
 
     @Test
     public void rollingAvgTick2Groups3OpsFloat() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var setup = """
         contains_row = rolling_avg_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
         before_row = rolling_avg_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingAvgTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingAvgTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(4);
+        runner.setRowFactor(3);
         runner.tables("timed");
 
         var setup = """
@@ -28,7 +28,7 @@ public class RollingAvgTimeTest {
 
     @Test
     public void rollingAvgTime0Group3Ops() {
-        runner.setRowFactor(6);
+        runner.setScaleFactors(3, 2);
         runner.tables("timed");
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingAvgTime- 3 Ops No Groups", q, "int5", "timestamp");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingComboTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingComboTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingComboTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(4);
+        runner.setRowFactor(3);
         runner.tables("timed");
         setupStr = """
         from deephaven.updateby import rolling_sum_time, rolling_min_time, rolling_prod_time

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingCountTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingCountTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingCountTickTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -41,7 +41,7 @@ public class RollingCountTickTest {
 
     @Test
     public void rollingCountTick2Groups3OpsInt() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
         runner.test("RollingCountTick- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
                 "int5");
@@ -49,7 +49,7 @@ public class RollingCountTickTest {
 
     @Test
     public void rollingCountTick2Groups3OpsFloat() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var setup = """
         contains_row = rolling_count_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
         before_row = rolling_count_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingCountTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingCountTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingCountTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(3);
         runner.tables("timed");
 
         var setup = """
@@ -28,6 +28,7 @@ public class RollingCountTimeTest {
 
     @Test
     public void rollingCountTime0Group3Ops() {
+        runner.setScaleFactors(3, 2);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingCountTime- 3 Ops No Groups", q, "int5", "timestamp");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingGroupTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingGroupTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingGroupTickTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -34,14 +34,14 @@ public class RollingGroupTickTest {
 
     @Test
     public void rollingGroupTick1Group3Ops() {
-        runner.setScaleFactors(2, 1);
+        runner.setScaleFactors(3, 1);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100'])";
         runner.test("RollingGroupTick- 3 Ops 1 Group 100 Unique Vals", q, "str100", "int5");
     }
 
     @Test
     public void rollingGroupTick2Groups3OpsInt() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
         runner.test("RollingGroupTick- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
                 "int5");
@@ -49,7 +49,7 @@ public class RollingGroupTickTest {
 
     @Test
     public void rollingGroupTick2Groups3OpsFloat() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var setup = """
         contains_row = rolling_group_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
         before_row = rolling_group_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingGroupTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingGroupTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingGroupTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(4);
+        runner.setRowFactor(3);
         runner.tables("timed");
 
         var setup = """
@@ -28,8 +28,7 @@ public class RollingGroupTimeTest {
 
     @Test
     public void rollingGroupTime0Group3Ops() {
-        runner.setRowFactor(6);
-        runner.tables("timed");
+        runner.setScaleFactors(3, 2);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingGroupTime- 3 Ops No Groups", q, "int5", "timestamp");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingMaxTickTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -27,7 +27,7 @@ public class RollingMaxTickTest {
 
     @Test
     public void rollingMaxTick0Group3Ops() {
-        runner.setScaleFactors(2, 2);
+        runner.setScaleFactors(2, 1);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingMaxTick- 3 Ops No Groups", q, "int5");
     }
@@ -41,7 +41,7 @@ public class RollingMaxTickTest {
 
     @Test
     public void rollingMaxTick2Groups3OpsInt() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
         runner.test("RollingMaxTick- 3 Ops 2 Groups 15K Unique Combos Int",  q, "str100", "str150",
                 "int5");
@@ -49,7 +49,7 @@ public class RollingMaxTickTest {
 
     @Test
     public void rollingMaxTick2Groups3OpsFloat() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var setup = """
         contains_row = rolling_max_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
         before_row = rolling_max_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMaxTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingMaxTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(4);
+        runner.setRowFactor(3);
         runner.tables("timed");
 
         var setup = """
@@ -28,6 +28,7 @@ public class RollingMaxTimeTest {
 
     @Test
     public void rollingMaxTime0Group3Ops() {
+        runner.setScaleFactors(2, 1);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingMaxTime- 3 Ops No Groups", q, "int5", "timestamp");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingMinTickTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -41,7 +41,7 @@ public class RollingMinTickTest {
 
     @Test
     public void rollingMinTick2Groups3OpsInt() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
         runner.test("RollingMinTick- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
                 "int5");
@@ -49,7 +49,7 @@ public class RollingMinTickTest {
 
     @Test
     public void rollingMinTick2Groups3OpsFloat() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var setup = """
         contains_row = rolling_min_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
         before_row = rolling_min_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingMinTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingMinTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(4);
+        runner.setRowFactor(3);
         runner.tables("timed");
 
         var setup = """
@@ -28,6 +28,7 @@ public class RollingMinTimeTest {
 
     @Test
     public void rollingMinTime0Group3Ops() {
+        runner.setScaleFactors(2, 1);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingMinTime- 3 Ops No Groups", q, "int5", "timestamp");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingProdTickTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -40,7 +40,7 @@ public class RollingProdTickTest {
 
     @Test
     public void rollingProdTick2Groups3OpsInt() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
         runner.test("RollingProdTick- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
                 "int5");
@@ -48,7 +48,7 @@ public class RollingProdTickTest {
 
     @Test
     public void rollingProdTick2Groups3OpsFloat() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var setup = """
         contains_row = rolling_prod_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
         before_row = rolling_prod_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingProdTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingProdTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(4);
+        runner.setRowFactor(3);
         runner.tables("timed");
 
         var setup = """

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingStdTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingStdTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingStdTickTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -27,7 +27,8 @@ public class RollingStdTickTest {
 
     @Test
     public void rollingStdTick0Group3Ops() {
-        runner.setScaleFactors(1, 1);
+        runner.setRowFactor(2);
+        runner.tables("timed");
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingStdTick- 3 Ops No Groups", q, "int5");
     }
@@ -41,7 +42,7 @@ public class RollingStdTickTest {
 
     @Test
     public void rollingStdTime2Groups3OpsInt() {
-        runner.setScaleFactors(2, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
         runner.test("RollingStdTick- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
                 "int5");
@@ -49,7 +50,7 @@ public class RollingStdTickTest {
 
     @Test
     public void rollingStdTick2Groups3OpsFloat() {
-        runner.setScaleFactors(2, 1);
+        runner.setScaleFactors(1, 1);
         var setup = """
         contains_row = rolling_std_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
         before_row = rolling_std_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingStdTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingStdTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingStdTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(4);
+        runner.setRowFactor(3);
         runner.tables("timed");
 
         var setup = """
@@ -28,7 +28,7 @@ public class RollingStdTimeTest {
 
     @Test
     public void rollingStdTime0Group3Ops() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(1);
         runner.tables("timed");
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingStdTime- 3 Ops No Groups", q, "int5", "timestamp");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingSumTickTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -41,7 +41,7 @@ public class RollingSumTickTest {
 
     @Test
     public void rollingSumTick2Groups3OpsInt() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
         runner.test("RollingSumTick- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
                 "int5");
@@ -49,7 +49,7 @@ public class RollingSumTickTest {
 
     @Test
     public void rollingSumTick2Groups3OpsFloat() {
-        runner.setScaleFactors(3, 1);
+        runner.setScaleFactors(1, 1);
         var setup = """
         contains_row = rolling_sum_tick(cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
         before_row = rolling_sum_tick(cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingSumTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingSumTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(4);
+        runner.setRowFactor(3);
         runner.tables("timed");
 
         var setup = """
@@ -28,8 +28,7 @@ public class RollingSumTimeTest {
 
     @Test
     public void rollingSumTime0Group3Ops() {
-        runner.setRowFactor(6);
-        runner.tables("timed");
+        runner.setScaleFactors(3, 2);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingSumTime- 3 Ops No Groups", q, "int5", "timestamp");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTickTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingWAvgTickTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(4);
         runner.tables("timed");
 
         var setup = """
@@ -27,6 +27,8 @@ public class RollingWAvgTickTest {
 
     @Test
     public void rollingWAvgTick0Group3Ops() {
+        runner.setRowFactor(3);
+        runner.tables("timed");
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingWAvgTick- 3 Ops No Groups", q, "int5", "int10");
     }
@@ -40,7 +42,7 @@ public class RollingWAvgTickTest {
 
     @Test
     public void rollingWAvgTime2Groups3OpsInt() {
-        runner.setScaleFactors(2, 1);
+        runner.setScaleFactors(1, 1);
         var q = "timed.update_by(ops=[contains_row, before_row, after_row], by=['str100','str150'])";
         runner.test("RollingWAvgTick- 3 Ops 2 Groups 15K Unique Combos Int", q, "str100", "str150",
                 "int5", "int10");
@@ -48,7 +50,7 @@ public class RollingWAvgTickTest {
 
     @Test
     public void rollingWAvgTick2Groups3OpsFloat() {
-        runner.setScaleFactors(2, 1);
+        runner.setScaleFactors(1, 1);
         var setup = """
         contains_row = rolling_wavg_tick('int10', cols=["Contains = float5"], rev_ticks=1, fwd_ticks=1)
         before_row = rolling_wavg_tick('int10', cols=["Before = float5"], rev_ticks=3, fwd_ticks=-1)

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/RollingWAvgTimeTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.tests.standard.updateby;
 
 import org.junit.jupiter.api.*;
@@ -13,7 +13,7 @@ public class RollingWAvgTimeTest {
 
     @BeforeEach
     public void setup() {
-        runner.setRowFactor(4);
+        runner.setRowFactor(3);
         runner.tables("timed");
 
         var setup = """
@@ -28,7 +28,7 @@ public class RollingWAvgTimeTest {
 
     @Test
     public void rollingWAvgTime0Group3Ops() {
-        runner.setRowFactor(6);
+        runner.setRowFactor(1);
         runner.tables("timed");
         var q = "timed.update_by(ops=[contains_row, before_row, after_row])";
         runner.test("RollingWAvgTime- 3 Ops No Groups", q, "int5", "timestamp", "int10");


### PR DESCRIPTION
- Added support for merge (simulates more rows than loaded) with timed tables
- Changed default data distribution, except for timestamp column, to random
- Re-scaled all updateby benchmarks
- Fixed an issue where "2 Groups 15K Unique Combos" benchmarks did not have 15K cardinality