### PR TITLE
Added javadoc hinting at why emmin and emmax op rates are so different

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTickTest.java
@@ -7,6 +7,9 @@ import io.deephaven.benchmark.tests.standard.StandardTestRunner;
 /**
  * Standard tests for the updateBy table operation. Calculates a tick-based exponential moving maximum for specified
  * columns and places the result into a new column for each row.
+ * <p/>
+ * Note: When there are no Group Keys, EmMaxTick has a much faster rate than EmMinTick. This is likely because of branch
+ * prediction on x86 systems. This disparity does not happen on Mac M1.
  */
 public class EmMaxTickTest {
     final StandardTestRunner runner = new StandardTestRunner(this);

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTimeTest.java
@@ -7,6 +7,9 @@ import io.deephaven.benchmark.tests.standard.StandardTestRunner;
 /**
  * Standard tests for the updateBy table operation. Calculates a time-based exponential moving maximum for specified
  * columns and places the result into a new column for each row.
+ * <p/>
+ * Note: When there are no Group Keys, EmMaxTime has a much faster rate than EmMinTime. This is likely because of branch
+ * prediction on x86 systems. This disparity does not happen on Mac M1.
  */
 public class EmMaxTimeTest {
     final StandardTestRunner runner = new StandardTestRunner(this);

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTickTest.java
@@ -7,6 +7,9 @@ import io.deephaven.benchmark.tests.standard.StandardTestRunner;
 /**
  * Standard tests for the updateBy table operation. Calculates a tick-based exponential moving minimum for specified
  * columns and places the result into a new column for each row.
+ * <p/>
+ * Note: When there are no Group Keys, EmMinTick has a much slower rate than EmMaxTick. This is likely because of branch
+ * prediction on x86 systems. This disparity does not happen on Mac M1.
  */
 public class EmMinTickTest {
     final StandardTestRunner runner = new StandardTestRunner(this);

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTimeTest.java
@@ -7,6 +7,9 @@ import io.deephaven.benchmark.tests.standard.StandardTestRunner;
 /**
  * Standard tests for the updateBy table operation. Calculates a time-based exponential moving minimum for specified
  * columns and places the result into a new column for each row.
+ * <p/>
+ * Note: When there are no Group Keys, EmMinTime has a much slower rate than EmMaxTime. This is likely because of branch
+ * prediction on x86 systems. This disparity does not happen on Mac M1.
  */
 public class EmMinTimeTest {
     final StandardTestRunner runner = new StandardTestRunner(this);


### PR DESCRIPTION
- Added some brief javadoc explanations as to why emmin and emmax tick and time operations that have no group keys are so far apart in terms of rate.