### PR TITLE
UI Workflows For Adhoc et al

### DIFF
--- a/.github/resources/adhoc-benchmark-docker-compose.yml
+++ b/.github/resources/adhoc-benchmark-docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server:edge
+    image: ghcr.io/deephaven/server:${DOCKER_IMG}
     ports:
       - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:

--- a/.github/resources/adhoc-scale-benchmark.properties
+++ b/.github/resources/adhoc-scale-benchmark.properties
@@ -24,7 +24,7 @@ generator.pause.per.row=0 millis
 record.compression=SNAPPY
 
 # Row count to scale tests (Tests can override but typically do not)
-scale.row.count=100000
+scale.row.count=${baseRowCount}
 
 # True: Use a timestamp for the parent directory of each test run
 # False: Overwrite previous test results for each test run

--- a/.github/resources/compare-benchmark-docker-compose.yml
+++ b/.github/resources/compare-benchmark-docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server:0.32.0
+    image: ghcr.io/deephaven/server:${DOCKER_IMG}
     ports:
       - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:

--- a/.github/resources/release-benchmark-docker-compose.yml
+++ b/.github/resources/release-benchmark-docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server:0.32.0
+    image: ghcr.io/deephaven/server:${DOCKER_IMG}
     ports:
       - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:

--- a/.github/scripts/fetch-results-local.sh
+++ b/.github/scripts/fetch-results-local.sh
@@ -10,9 +10,11 @@ set -o nounset
 HOST=$1
 USER=$2
 RUN_TYPE=$3
+ACTOR=${4:-}
+RUN_LABEL=${5:-}
 RUN_DIR=/root/run
 
-if [[ $# != 3 ]]; then
+if [[ $# != 3 ]] && [[ $# != 5 ]]; then
     echo "$0: Missing host, user, or run type arguments"
     exit 1
 fi
@@ -20,23 +22,36 @@ fi
 # Pull results from the benchmark server
 scp -r ${USER}@${HOST}:${RUN_DIR}/results .
 scp -r ${USER}@${HOST}:${RUN_DIR}/logs .
-rm -rf ${RUN_TYPE}
-mv results/ ${RUN_TYPE}/
+
+# If the RUN_TYPE is adhoc, userfy the destination directory
+DEST_DIR=${RUN_TYPE}
+if [ "${RUN_TYPE}" = "adhoc" ]; then
+    if [ -z "${ACTOR}" ] || [ -z "${RUN_LABEL}" ]; then
+        echo "$0: Missing actor of run label argument for adhoc run type"
+        exit 1
+    fi
+    DEST_DIR=${RUN_TYPE}/${ACTOR}/${RUN_LABEL}
+    mkdir -p ${DEST_DIR}
+fi
+
+rm -rf ${DEST_DIR}
+mv results/ ${DEST_DIR}/
 
 # For now remove any unwanted summaries before uploading to GCloud
-rm -f ${RUN_TYPE}/*.csv
+rm -f ${DEST_DIR}/*.csv
 
 # Rename the svg summary table according to run type. Discard the rest
-TMP_SVG_DIR=${RUN_TYPE}/tmp-svg
+TMP_SVG_DIR=${DEST_DIR}/tmp-svg
 mkdir -p ${TMP_SVG_DIR}
-mv ${RUN_TYPE}/*.svg ${TMP_SVG_DIR}
-mv ${TMP_SVG_DIR}/${RUN_TYPE}-benchmark-summary.svg ${RUN_TYPE}/benchmark-summary.svg
+mv ${DEST_DIR}/*.svg ${TMP_SVG_DIR}
+mv ${TMP_SVG_DIR}/${RUN_TYPE}-benchmark-summary.svg ${DEST_DIR}/benchmark-summary.svg
 rm -rf ${TMP_SVG_DIR}
 
 # Compress CSV and Test Logs
-for runId in `find ${RUN_TYPE}/ -name "run-*"`
+for runId in `find ${DEST_DIR}/ -name "run-*"`
 do
     (cd ${runId}; gzip *.csv)
     (cd ${runId}/test-logs; tar -zcvf test-logs.tgz *; mv test-logs.tgz ../)
     rm -rf ${runId}/test-logs/
 done
+

--- a/.github/scripts/fetch-results-local.sh
+++ b/.github/scripts/fetch-results-local.sh
@@ -15,7 +15,7 @@ RUN_LABEL=${5:-}
 RUN_DIR=/root/run
 
 if [[ $# != 3 ]] && [[ $# != 5 ]]; then
-    echo "$0: Missing host, user, or run type arguments"
+    echo "$0: Missing host, user, run type, actor, or run label arguments"
     exit 1
 fi
 

--- a/.github/scripts/run-benchmarks-remote.sh
+++ b/.github/scripts/run-benchmarks-remote.sh
@@ -7,26 +7,33 @@ set -o nounset
 # Run benchmarks on the remote side
 # Assumes the deephaven-benchmark-*.jar artifact has been built and placed
 
-if [[ $# != 1 ]]; then
-  echo "$0: Missing run type argument"
+if [[ $# != 4 ]]; then
+  echo "$0: Missing run type, test package, test regex, or row count argument"
   exit 1
 fi
 
 RUN_TYPE=$1
+TEST_PKG=$2
+TEST_RGX=$3
+ROW_COUNT=$4
 HOST=`hostname`
 RUN_DIR=/root/run
 DEEPHAVEN_DIR=/root/deephaven
 
 # Match run type (nightly, release, compare, adhoc) to benchmark test package
+# Note: Default TEST_PATTERN taken from default -n option in Junit Platform Console Standalone
 case ${RUN_TYPE} in
   adhoc)
-    TEST_PACKAGE=io.deephaven.benchmark.tests.standard.aggby
+    TEST_PACKAGE=${TEST_PKG}
+    TEST_PATTERN=${TEST_RGX}
     ;;
   compare)
     TEST_PACKAGE=io.deephaven.benchmark.tests.compare
+    TEST_PATTERN="^(Test.*|.+[.$]Test.*|.*Tests?)$"
     ;;
   *)
     TEST_PACKAGE=io.deephaven.benchmark.tests.standard
+    TEST_PATTERN="^(Test.*|.+[.$]Test.*|.*Tests?)$"
     ;;
 esac
 
@@ -47,8 +54,10 @@ rm -f data/*.*
 docker compose up -d
 sleep 10
 
+title "-- Running Benchmarks --"
 cd ${RUN_DIR}
-java -Dbenchmark.profile=${RUN_TYPE}-scale-benchmark.properties -jar deephaven-benchmark-*.jar -cp standard-tests.jar -p ${TEST_PACKAGE}
+cat ${RUN_TYPE}-scale-benchmark.properties | sed 's|${baseRowCount}|'"${ROW_COUNT}|g" > scale-benchmark.properties
+java -Dbenchmark.profile=scale-benchmark.properties -jar deephaven-benchmark-*.jar -cp standard-tests.jar -p ${TEST_PACKAGE} -n "${TEST_PATTERN}"
 
 title "-- Getting Docker Logs --"
 mkdir -p ${RUN_DIR}/logs

--- a/.github/scripts/run-benchmarks-remote.sh
+++ b/.github/scripts/run-benchmarks-remote.sh
@@ -13,29 +13,12 @@ if [[ $# != 4 ]]; then
 fi
 
 RUN_TYPE=$1
-TEST_PKG=$2
-TEST_RGX=$3
+TEST_PACKAGE=$2
+TEST_PATTERN=$3
 ROW_COUNT=$4
 HOST=`hostname`
 RUN_DIR=/root/run
 DEEPHAVEN_DIR=/root/deephaven
-
-# Match run type (nightly, release, compare, adhoc) to benchmark test package
-# Note: Default TEST_PATTERN taken from default -n option in Junit Platform Console Standalone
-case ${RUN_TYPE} in
-  adhoc)
-    TEST_PACKAGE=${TEST_PKG}
-    TEST_PATTERN=${TEST_RGX}
-    ;;
-  compare)
-    TEST_PACKAGE=io.deephaven.benchmark.tests.compare
-    TEST_PATTERN="^(Test.*|.+[.$]Test.*|.*Tests?)$"
-    ;;
-  *)
-    TEST_PACKAGE=io.deephaven.benchmark.tests.standard
-    TEST_PATTERN="^(Test.*|.+[.$]Test.*|.*Tests?)$"
-    ;;
-esac
 
 if [ ! -d "${RUN_DIR}" ]; then
   echo "$0: Missing the Benchmark run directory"

--- a/.github/scripts/run-benchmarks-remote.sh
+++ b/.github/scripts/run-benchmarks-remote.sh
@@ -14,7 +14,7 @@ fi
 
 RUN_TYPE=$1
 TEST_PACKAGE=$2
-TEST_PATTERN=$3
+TEST_PATTERN="$3"
 ROW_COUNT=$4
 HOST=`hostname`
 RUN_DIR=/root/run

--- a/.github/scripts/run-ssh-local.sh
+++ b/.github/scripts/run-ssh-local.sh
@@ -4,18 +4,23 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-# Runs the remote server setup and benchmark run from github workflow
+# Executes a local script on a remote server while storing output relative to the 
+# local working directory. Also, this script wraps arguments provided for the
+# remote scripts in single-quotes to avoid syntax errors.
 
 HOST=$1
 USER=$2
 SCRIPT_DIR=$3
 SCRIPT_NAME=$4
 
-
 if [[ $# -lt 4 ]]; then
-	echo "$0: Wrong number of arguments"
+	echo "$0: Missing host, user, script dir, or script name argument"
 	exit 1
 fi
 
-ssh -o 'ServerAliveInterval 60' ${USER}@${HOST} 'bash -s' "${@:5}" < ${SCRIPT_DIR}/${SCRIPT_NAME}.sh |& tee logs/${SCRIPT_NAME}.log
+args=()
+for i in ${@:5}; do
+  args+=("'"$i"'")
+done
 
+ssh -o 'ServerAliveInterval 60' ${USER}@${HOST} 'bash -s' "${args[*]}" < ${SCRIPT_DIR}/${SCRIPT_NAME}.sh |& tee logs/${SCRIPT_NAME}.log

--- a/.github/scripts/setup-test-server-remote.sh
+++ b/.github/scripts/setup-test-server-remote.sh
@@ -11,8 +11,8 @@ if [ ! -d "/root" ]; then
   exit 1
 fi
 
-if [[ $# != 3 ]]; then
-  echo "$0: Missing repo, branch, or run type arguments"
+if [[ $# != 4 ]]; then
+  echo "$0: Missing repo, branch, run type, or docker image argument"
   exit 1
 fi
 
@@ -21,6 +21,7 @@ GIT_DIR=/root/git
 GIT_REPO=$1
 GIT_BRANCH=$2
 RUN_TYPE=$3                     # ex. nightly | release | compare
+DOCKER_IMG=$4			# ex. edge | 0.32.0 (assumes location ghcr.io/deephaven/server)
 DEEPHAVEN_DIR=/root/deephaven
 
 title () { echo; echo $1; }
@@ -78,8 +79,12 @@ title "-- Installing Deephaven and Redpanda --"
 mkdir -p ${DEEPHAVEN_DIR}
 cd ${DEEPHAVEN_DIR}
 cp ${GIT_DIR}/benchmark/.github/resources/${RUN_TYPE}-benchmark-docker-compose.yml docker-compose.yml
+echo "DOCKER_IMG=${DOCKER_IMG}" > .env
 docker compose pull
 
 title "-- Starting Deephaven and Redpanda --"
 docker compose up -d
+
+
+
 

--- a/.github/workflows/adhoc-remote-benchmarks.yml
+++ b/.github/workflows/adhoc-remote-benchmarks.yml
@@ -9,7 +9,31 @@ name: Adhoc Benchmark Test on Docker Deephaven
 
 on:
   workflow_dispatch:
-    branches: [ "**" ]
+   inputs:
+     docker_image:
+       description: 'Docker Image Name'
+       required: true
+       default: 'edge'
+       type: string
+     run_label:
+       description: 'Run Label'
+       required: true
+       type: string
+     test_package:
+       description: 'Benchmark Test Package'
+       required: true
+       default: 'io.deephaven.benchmark.tests'
+       type: string
+     test_class_regex:
+       description: 'Benchmark Test Class Pattern'
+       required: true
+       default: '^.*[.]MixedCombo.*Test.*$'
+       type: string
+     scale_row_count:
+       description: 'Benchmark Scale Row Count'
+       required: true
+       default: '1000000'
+       type: string
 
 jobs:
   process-release-benchmarks:
@@ -17,4 +41,9 @@ jobs:
     uses: ./.github/workflows/remote-benchmarks.yml
     with:
       run-type: adhoc
+      docker_image: ${{ inputs.docker_image }}
+      run_label: ${{ inputs.run_label }}
+      test_package: ${{ inputs.test_package }}
+      test_class_regex: ${{ inputs.test_class_regex }}
+      scale_row_count: ${{ inputs.scale_row_count }} 
     secrets: inherit

--- a/.github/workflows/adhoc-remote-benchmarks.yml
+++ b/.github/workflows/adhoc-remote-benchmarks.yml
@@ -40,7 +40,7 @@ jobs:
     if: ${{github.repository_owner != 'deephaven'}}
     uses: ./.github/workflows/remote-benchmarks.yml
     with:
-      run-type: adhoc
+      run_type: adhoc
       docker_image: ${{ inputs.docker_image }}
       run_label: ${{ inputs.run_label }}
       test_package: ${{ inputs.test_package }}

--- a/.github/workflows/compare-remote-benchmarks.yml
+++ b/.github/workflows/compare-remote-benchmarks.yml
@@ -7,11 +7,21 @@ name: Compare Benchmark Test on Docker Deephaven
 
 on:
   workflow_dispatch:
-    branches: [ "**" ]
+    inputs:
+     docker_image:
+       description: 'Docker Image Name'
+       required: true
+       default: '0.32.0'
+       type: string
 
 jobs:
   process-release-benchmarks:
     uses: ./.github/workflows/remote-benchmarks.yml
     with:
       run_type: compare
+      docker_image: ${{ inputs.docker_image }}
+      run_label: ""
+      test_package: "io.deephaven.benchmark.tests.standard"
+      test_class_regex: "^(Test.*|.+[.$]Test.*|.*Tests?)$"
+      scale_row_count: 70000000
     secrets: inherit

--- a/.github/workflows/compare-remote-benchmarks.yml
+++ b/.github/workflows/compare-remote-benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
       run_type: compare
       docker_image: ${{ inputs.docker_image }}
       run_label: ""
-      test_package: "io.deephaven.benchmark.tests.standard"
+      test_package: "io.deephaven.benchmark.tests.compare"
       test_class_regex: "^(Test.*|.+[.$]Test.*|.*Tests?)$"
       scale_row_count: 70000000
     secrets: inherit

--- a/.github/workflows/compare-remote-benchmarks.yml
+++ b/.github/workflows/compare-remote-benchmarks.yml
@@ -13,5 +13,5 @@ jobs:
   process-release-benchmarks:
     uses: ./.github/workflows/remote-benchmarks.yml
     with:
-      run-type: compare
+      run_type: compare
     secrets: inherit

--- a/.github/workflows/nightly-remote-benchmarks.yml
+++ b/.github/workflows/nightly-remote-benchmarks.yml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/remote-benchmarks.yml
     with:
       run_type: nightly
-      docker_image: ${{ inputs.docker_image }}
+      docker_image: "edge"
       run_label: ""
       test_package: "io.deephaven.benchmark.tests.standard"
       test_class_regex: "^(Test.*|.+[.$]Test.*|.*Tests?)$"

--- a/.github/workflows/nightly-remote-benchmarks.yml
+++ b/.github/workflows/nightly-remote-benchmarks.yml
@@ -13,4 +13,9 @@ jobs:
     uses: ./.github/workflows/remote-benchmarks.yml
     with:
       run_type: nightly
+      docker_image: ${{ inputs.docker_image }}
+      run_label: ""
+      test_package: "io.deephaven.benchmark.tests.standard"
+      test_class_regex: "^(Test.*|.+[.$]Test.*|.*Tests?)$"
+      scale_row_count: 10000000
     secrets: inherit

--- a/.github/workflows/nightly-remote-benchmarks.yml
+++ b/.github/workflows/nightly-remote-benchmarks.yml
@@ -12,5 +12,5 @@ jobs:
     if: ${{github.repository_owner == 'deephaven'}}
     uses: ./.github/workflows/remote-benchmarks.yml
     with:
-      run-type: nightly
+      run_type: nightly
     secrets: inherit

--- a/.github/workflows/release-remote-benchmarks.yml
+++ b/.github/workflows/release-remote-benchmarks.yml
@@ -12,5 +12,5 @@ jobs:
   process-release-benchmarks:
     uses: ./.github/workflows/remote-benchmarks.yml
     with:
-      run-type: release
+      run_type: release
     secrets: inherit

--- a/.github/workflows/release-remote-benchmarks.yml
+++ b/.github/workflows/release-remote-benchmarks.yml
@@ -6,11 +6,21 @@ name: Release Benchmark Test on Docker Deephaven
 
 on:
   workflow_dispatch:
-    branches: [ "**" ]
+    inputs:
+     docker_image:
+       description: 'Docker Image Name'
+       required: true
+       default: '0.32.0'
+       type: string
 
 jobs:
   process-release-benchmarks:
     uses: ./.github/workflows/remote-benchmarks.yml
     with:
       run_type: release
+      docker_image: ${{ inputs.docker_image }}
+      run_label: ""
+      test_package: "io.deephaven.benchmark.tests.standard"
+      test_class_regex: "^(Test.*|.+[.$]Test.*|.*Tests?)$"
+      scale_row_count: 10000000
     secrets: inherit

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Docker Pull Deephaven and Redpanda
       run: |
-      	cp .github/resources/${RUN_TYPE}-benchmark-docker-compose.yml docker-compose.yml
+        cp .github/resources/${RUN_TYPE}-benchmark-docker-compose.yml docker-compose.yml
         docker compose pull
 
     - name: Docker Up Deephaven and Redpanda

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -75,7 +75,7 @@ jobs:
 
     - name: Run Remote Test Server Setup
       run: |
-        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} setup-test-server-remote ${REPO} ${BRANCH} ${RUN_TYPE} ${DOCKER_IMG}
+        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} setup-test-server-remote ${REPO} ${BRANCH} ${RUN_TYPE} "${DOCKER_IMG}"
 
     - name: Run Remote Benchmark Artifact Build
       run: |
@@ -83,11 +83,11 @@ jobs:
 
     - name: Run Remote Benchmarks
       run: |
-        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} run-benchmarks-remote ${RUN_TYPE} ${TEST_PKG} ${TEST_RGX} ${ROW_CNT}
+        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} run-benchmarks-remote ${RUN_TYPE} "${TEST_PKG}" "${TEST_RGX}" ${ROW_CNT}
         
     - name: Fetch Benchmark Results and Prepare for Upload
       run: |
-        ${SD}/fetch-results-local.sh ${HOST} ${USER} ${RUN_TYPE} ${ACTOR} ${RUN_LABEL}
+        ${SD}/fetch-results-local.sh ${HOST} ${USER} ${RUN_TYPE} "${ACTOR}" "${RUN_LABEL}"
 
     - name: Authorize GCloud Credentials
       uses: google-github-actions/auth@v1

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
       DOCKER_IMG: ${{inputs.docker_image}}
       RUN_LABEL: ${{inputs.run_label}}
       TEST_PKG: ${{inputs.test_package}}
-      TEST_RGX: "${{inputs.test_class_regex}}"
+      TEST_RGX: "\u0027${{inputs.test_class_regex}}\u0027"
       ROW_CNT: ${{inputs.scale_row_count}}
       ACTOR: ${{github.actor}}
 

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -82,7 +82,7 @@ jobs:
 
     - name: Run Remote Benchmarks
       run: |
-        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} run-benchmarks-remote ${RUN_TYPE} ${TEST_PKG} ${TEST_RGX} ${ROW_COUNT}
+        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} run-benchmarks-remote ${RUN_TYPE} ${TEST_PKG} ${TEST_RGX} ${ROW_CNT}
         
     - name: Fetch Benchmark Results and Prepare for Upload
       run: |

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -1,5 +1,5 @@
 # Run benchmarks on a remote system for the release the project is using
-# - This workflow is reusable with run-type set to release or nightly
+# - This workflow is reusable with run_type set to release or nightly
 # - Scripts ending in "-local" run on the github runner
 # - Scripts ending in "-remote" run are executed on the remote test server through ssh
 
@@ -8,7 +8,22 @@ name: Benchmark Test on Docker Deephaven
 on:
   workflow_call:
     inputs:
-      run-type:
+      run_type:
+        required: true
+        type: string
+      docker_image:
+       required: true
+       type: string
+      run_label:
+        required: true
+        type: string
+      test_package:
+        required: true
+        type: string
+      test_class_regex:
+        required: true
+        type: string
+      scale_row_count:
         required: true
         type: string
 
@@ -22,7 +37,13 @@ jobs:
       USER: ${{secrets.BENCHMARK_USER}}
       REPO: ${{github.repository}}
       BRANCH: ${{github.ref_name}}
-      RUN_TYPE: ${{inputs.run-type}}
+      RUN_TYPE: ${{inputs.run_type}}
+      DOCKER_IMG: ${{inputs.docker_image}}
+      RUN_LABEL: ${{inputs.run_label}}
+      TEST_PKG: ${{inputs.test_package}}
+      TEST_RGX: ${{inputs.test_class_regex}}
+      ROW_CNT: ${{inputs.scale_row_count}}
+      ACTOR: ${{github.actor}}
 
     steps:
     - uses: actions/checkout@v3
@@ -35,7 +56,7 @@ jobs:
 
     - name: Docker Pull Deephaven and Redpanda
       run: |
-        cp .github/resources/${RUN_TYPE}-benchmark-docker-compose.yml docker-compose.yml
+      	cp .github/resources/${RUN_TYPE}-benchmark-docker-compose.yml docker-compose.yml
         docker compose pull
 
     - name: Docker Up Deephaven and Redpanda
@@ -53,7 +74,7 @@ jobs:
 
     - name: Run Remote Test Server Setup
       run: |
-        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} setup-test-server-remote ${REPO} ${BRANCH} ${RUN_TYPE}
+        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} setup-test-server-remote ${REPO} ${BRANCH} ${RUN_TYPE} ${DOCKER_IMG}
 
     - name: Run Remote Benchmark Artifact Build
       run: |
@@ -61,11 +82,11 @@ jobs:
 
     - name: Run Remote Benchmarks
       run: |
-        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} run-benchmarks-remote ${RUN_TYPE}
+        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} run-benchmarks-remote ${RUN_TYPE} ${TEST_PKG} ${TEST_RGX} ${ROW_COUNT}
         
     - name: Fetch Benchmark Results and Prepare for Upload
       run: |
-        ${SD}/fetch-results-local.sh ${HOST} ${USER} ${RUN_TYPE}
+        ${SD}/fetch-results-local.sh ${HOST} ${USER} ${RUN_TYPE} ${ACTOR} ${RUN_LABEL}
 
     - name: Authorize GCloud Credentials
       uses: google-github-actions/auth@v1

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -57,6 +57,7 @@ jobs:
     - name: Docker Pull Deephaven and Redpanda
       run: |
         cp .github/resources/${RUN_TYPE}-benchmark-docker-compose.yml docker-compose.yml
+        echo "DOCKER_IMG=${DOCKER_IMG}" > .env
         docker compose pull
 
     - name: Docker Up Deephaven and Redpanda

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
       DOCKER_IMG: ${{inputs.docker_image}}
       RUN_LABEL: ${{inputs.run_label}}
       TEST_PKG: ${{inputs.test_package}}
-      TEST_RGX: ${{inputs.test_class_regex}}
+      TEST_RGX: "${{inputs.test_class_regex}}"
       ROW_CNT: ${{inputs.scale_row_count}}
       ACTOR: ${{github.actor}}
 

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
       DOCKER_IMG: ${{inputs.docker_image}}
       RUN_LABEL: ${{inputs.run_label}}
       TEST_PKG: ${{inputs.test_package}}
-      TEST_RGX: "\u0027${{inputs.test_class_regex}}\u0027"
+      TEST_RGX: ${{inputs.test_class_regex}}
       ROW_CNT: ${{inputs.scale_row_count}}
       ACTOR: ${{github.actor}}
 


### PR DESCRIPTION
- Parameterized workflows, resources, and scripts to allow user-provided values to be used
   - ex. user-provided docker image name is now automatically placed in the _docker-compose.yml_ used for testing
   - ex. scale row count is placed in the scale-benchmark.properties file
- For adhoc builds, the result path in the GCloud bucket is changed to include user (actor) and a user-supplied path in the name
   - ex. deephaven-benchmark/adhoc/stanbrub/myrun/
- Release, Compare, and Nightly workflows still produce the same result
- UI and Defaults Specified for all workflows
- Adhoc Workflow UI
   - UI Fields; docker_image, run_label, test_package, test_class_regex, scale_row_count
   - Defaults added according to those previously hardcoded in docker-compose  and properties
- Compare and Release UI
   - UI Fields: docker_image
   - Defaults added according to those previously hardcoded in docker-compose  and properties
- Nightly
   - Fields: No UI Fields
   - Defaults are passed to the remote-benchmark workflow but are largely ignored
- Fixed an issue with patterns like `^.*[.]MixedCombo.*Test.*$` being passed as parameters to remote-executing bash scripts