### PR TITLE
Upgraded to JVM 21 and Barrage 0.32.0

### DIFF
--- a/.github/resources/adhoc-scale-benchmark.properties
+++ b/.github/resources/adhoc-scale-benchmark.properties
@@ -21,7 +21,7 @@ default.completion.timeout=10 minutes
 generator.pause.per.row=0 millis
 
 # Compression used for generating and storing records (SNAPPY, ZSTD, LZ4, LZO, GZIP, NONE) 
-record.compression=SNAPPY
+record.compression=LZO
 
 # Row count to scale tests (Tests can override but typically do not)
 scale.row.count=${baseRowCount}

--- a/.github/resources/compare-scale-benchmark.properties
+++ b/.github/resources/compare-scale-benchmark.properties
@@ -21,7 +21,7 @@ default.completion.timeout=10 minutes
 generator.pause.per.row=0 millis
 
 # Compression used for generating and storing records (SNAPPY, ZSTD, LZ4, LZO, GZIP, NONE) 
-record.compression=SNAPPY
+record.compression=LZO
 
 # Row count to scale tests (Tests can override but typically do not)
 scale.row.count=70000000

--- a/.github/scripts/setup-test-server-remote.sh
+++ b/.github/scripts/setup-test-server-remote.sh
@@ -31,8 +31,8 @@ title "- Setting Up Remote Benchmark Testing on ${HOST} -"
 title "-- Adding OS Applications --"
 apt update
 
-title "-- Installing JDK 17 --"
-apt install openjdk-17-jre-headless
+title "-- Installing JDK 21 --"
+apt install openjdk-21-jre-headless
 
 title "-- Installing Maven --"
 apt install maven

--- a/.github/workflows/mvn-integration-test.yml
+++ b/.github/workflows/mvn-integration-test.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
 

--- a/.github/workflows/mvn-package.yml
+++ b/.github/workflows/mvn-package.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>17</source>
-					<target>17</target>
+					<source>21</source>
+					<target>21</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -210,12 +210,12 @@
 		<dependency>
 			<groupId>io.deephaven</groupId>
 			<artifactId>deephaven-java-client-barrage-dagger</artifactId>
-			<version>0.31.0</version>
+			<version>0.32.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.deephaven</groupId>
 			<artifactId>deephaven-log-to-slf4j</artifactId>
-			<version>0.31.0</version>
+			<version>0.32.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>

--- a/src/main/java/io/deephaven/benchmark/controller/DeephavenDockerController.java
+++ b/src/main/java/io/deephaven/benchmark/controller/DeephavenDockerController.java
@@ -1,8 +1,8 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.controller;
 
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -75,12 +75,15 @@ public class DeephavenDockerController implements Controller {
     }
 
     /**
-     * Get the docker compose log since starting the Deephaven service.
+     * Get the docker compose log since starting the Deephaven service. If no docker compose is specified, do nothing,
+     * since the logs will get progressively bigger without a restart.
      * 
      * @return the text collected from docker compose log
      */
     @Override
     public String getLog() {
+        if (composePropPath.isBlank() || httpHostPort.isBlank())
+            return "";
         var composePath = getRunningComposePath();
         if (composePath != null)
             return exec("sudo docker compose -f " + composePath + " logs");
@@ -114,8 +117,8 @@ public class DeephavenDockerController implements Controller {
 
     URL createUrl(String uri) {
         try {
-            return new URL(uri);
-        } catch (MalformedURLException e) {
+            return new URI(uri).toURL();
+        } catch (Exception e) {
             throw new RuntimeException("Bad URL: " + uri);
         }
     }


### PR DESCRIPTION
- Changed to JVM 21 for builds and Github workflows
- Fixed a logging issue where captured logs were getting huge
  - Turned off log capture when tests are run back-to-back without restart
- Fixed a deprecated URL constructor
- Tested workflow changes from branch