### PR TITLE
Adhoc benchmarks from deephaven core branch

### DIFF
--- a/.github/resources/adhoc-benchmark-docker-compose.yml
+++ b/.github/resources/adhoc-benchmark-docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server:${DOCKER_IMG}
+    image: ${DOCKER_IMG}
     ports:
       - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:

--- a/.github/resources/compare-benchmark-docker-compose.yml
+++ b/.github/resources/compare-benchmark-docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server:${DOCKER_IMG}
+    image: ${DOCKER_IMG}
     ports:
       - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:

--- a/.github/resources/release-benchmark-docker-compose.yml
+++ b/.github/resources/release-benchmark-docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   deephaven:
-    image: ghcr.io/deephaven/server:${DOCKER_IMG}
+    image: ${DOCKER_IMG}
     ports:
       - "${DEEPHAVEN_PORT:-10000}:10000"
     volumes:

--- a/.github/scripts/build-docker-image-remote.sh
+++ b/.github/scripts/build-docker-image-remote.sh
@@ -43,14 +43,14 @@ BRANCH_NAME=${splitarr[1]}
 title "-- Cloning deephaven-core --"
 cd ${GIT_DIR}
 rm -rf deephaven-core 
-git clone git@github.com:${OWNER}/deephaven-core.git
+git clone https://github.com/${OWNER}/deephaven-core.git
 cd deephaven-core
 git checkout ${BRANCH_NAME}
 
 title "-- Cloning deephaven-server-docker --"
 cd ${GIT_DIR}
 rm -rf deephaven-server-docker
-git clone git@github.com:deephaven/deephaven-server-docker.git
+git clone https://github.com/${OWNER}/deephaven-server-docker.git
 cd deephaven-server-docker
 git checkout main
 

--- a/.github/scripts/build-docker-image-remote.sh
+++ b/.github/scripts/build-docker-image-remote.sh
@@ -2,7 +2,6 @@
 
 set -o errexit
 set -o pipefail
-set -o nounset
 
 # Build a local docker image on the remote side if needed
 # Ensure the docker image is running in the Deephaven directory
@@ -56,7 +55,7 @@ git checkout main
 
 title "-- Assembling Python Deephaven Core Server --"
 cd ${GIT_DIR}/deephaven-core
-OLD_JAVA_HOME="${JAVA_HOME:-}"
+OLD_JAVA_HOME="${JAVA_HOME}"
 export JAVA_HOME=/usr/lib/jvm/${JAVA}
 ./gradlew outputVersion server-jetty-app:assemble py-server:assemble
 export DEEPHAVEN_VERSION=$(cat build/version)

--- a/.github/scripts/build-docker-image-remote.sh
+++ b/.github/scripts/build-docker-image-remote.sh
@@ -59,8 +59,11 @@ cd ${GIT_DIR}/deephaven-core
 OLD_JAVA_HOME="${JAVA_HOME}"
 export JAVA_HOME=/usr/lib/jvm/${BUILD_JAVA}
 ./gradlew outputVersion server-jetty-app:assemble py-server:assemble
+title "-- Finished Assembly Build --"
 export DEEPHAVEN_VERSION=$(cat build/version)
+title "-- Deephaven Version ${DEEPHAVEN_VERSION}--"
 export JAVA_HOME="${OLD_JAVA_HOME}"
+title "-- Restored Java Home --"
 
 title "-- Building Deephaven Docker Image --"
 cd ${GIT_DIR}/deephaven-server-docker

--- a/.github/scripts/build-docker-image-remote.sh
+++ b/.github/scripts/build-docker-image-remote.sh
@@ -50,7 +50,7 @@ git checkout ${BRANCH_NAME}
 title "-- Cloning deephaven-server-docker --"
 cd ${GIT_DIR}
 rm -rf deephaven-server-docker
-git clone https://github.com/${OWNER}/deephaven-server-docker.git
+git clone https://github.com/deephaven/deephaven-server-docker.git
 cd deephaven-server-docker
 git checkout main
 

--- a/.github/scripts/build-docker-image-remote.sh
+++ b/.github/scripts/build-docker-image-remote.sh
@@ -9,14 +9,14 @@ set -o pipefail
 HOST=`hostname`
 GIT_DIR=/root/git
 DEEPHAVEN_DIR=/root/deephaven
-DEEPHAVEN_VERSION=${GIT_DIR}/deephaven-server-docker/build/version
+DEEPHAVEN_VERSION_FILE=${GIT_DIR}/deephaven-core/build/version
 
 if [ ! -d "${DEEPHAVEN_DIR}" ]; then
   echo "$0: Missing one or more Benchmark setup directories"
   exit 1
 fi
 
-if [ ! -f "${DEEPHAVEN_VERSION}" ]; then
+if [ ! -f "${DEEPHAVEN_VERSION_FILE}" ]; then
   echo "$0: Missing Deephaven version file. Was the project built first?"
   exit 1
 fi
@@ -36,7 +36,7 @@ fi
 
 
 title "-- Building Deephaven Docker Image --"
-export DEEPHAVEN_VERSION=$(cat ${DEEPHAVEN_VERSION})
+export DEEPHAVEN_VERSION=$(cat ${DEEPHAVEN_VERSION_FILE})
 cd ${GIT_DIR}/deephaven-server-docker
 cp ${GIT_DIR}/deephaven-core/server/jetty-app/build/distributions/server-jetty-*.tar contexts/server/
 cp ${GIT_DIR}/deephaven-core/server/jetty-app/build/distributions/server-jetty-*.tar contexts/server-slim/

--- a/.github/scripts/build-docker-image-remote.sh
+++ b/.github/scripts/build-docker-image-remote.sh
@@ -28,6 +28,7 @@ title () { echo; echo $1; }
 title "- Setting up Remote Docker Image on ${HOST} -"
 
 if [[ ${DOCKER_IMG} != *"${BRANCH_DELIM}"* ]]; then
+  cd ${DEEPHAVEN_DIR}
   echo "DOCKER_IMG=ghcr.io/deephaven/server:${DOCKER_IMG}" > .env
   docker compose pull
   title "-- Starting Deephaven and Redpanda --"
@@ -76,6 +77,7 @@ echo "DEEPHAVEN_CORE_WHEEL: ${DEEPHAVEN_CORE_WHEEL}"
 docker buildx bake -f server.hcl
 
 title "-- Starting Deephaven and Redpanda --"
+cd ${DEEPHAVEN_DIR}
 echo "DOCKER_IMG=deephaven/server:benchmark-local" > .env
 docker compose up -d
 

--- a/.github/scripts/build-docker-image-remote.sh
+++ b/.github/scripts/build-docker-image-remote.sh
@@ -9,7 +9,7 @@ set -o pipefail
 HOST=`hostname`
 GIT_DIR=/root/git
 DEEPHAVEN_DIR=/root/deephaven
-DEEPHAVEN_VERSION=build/version
+DEEPHAVEN_VERSION=${GIT_DIR}/deephaven-server-docker/build/version
 
 if [ ! -d "${DEEPHAVEN_DIR}" ]; then
   echo "$0: Missing one or more Benchmark setup directories"

--- a/.github/scripts/build-docker-image-remote.sh
+++ b/.github/scripts/build-docker-image-remote.sh
@@ -25,16 +25,6 @@ title () { echo; echo $1; }
 
 title "- Setting up Remote Docker Image on ${HOST} -"
 
-if [[ ${DOCKER_IMG} != *"${BRANCH_DELIM}"* ]]; then
-  cd ${DEEPHAVEN_DIR}
-  echo "DOCKER_IMG=ghcr.io/deephaven/server:${DOCKER_IMG}" > .env
-  docker compose pull
-  title "-- Starting Deephaven and Redpanda --"
-  docker compose up -d
-  exit 0
-fi
-
-
 title "-- Building Deephaven Docker Image --"
 export DEEPHAVEN_VERSION=$(cat ${DEEPHAVEN_VERSION_FILE})
 cd ${GIT_DIR}/deephaven-server-docker
@@ -49,11 +39,4 @@ export TAG=benchmark-local
 echo "DEEPHAVEN_VERSION: ${DEEPHAVEN_VERSION}"
 echo "DEEPHAVEN_CORE_WHEEL: ${DEEPHAVEN_CORE_WHEEL}"
 docker buildx bake -f server.hcl
-
-title "-- Starting Deephaven and Redpanda --"
-cd ${DEEPHAVEN_DIR}
-echo "DOCKER_IMG=deephaven/server:benchmark-local" > .env
-docker compose up -d
-
-
 

--- a/.github/scripts/build-docker-image-remote.sh
+++ b/.github/scripts/build-docker-image-remote.sh
@@ -58,12 +58,12 @@ title "-- Assembling Python Deephaven Core Server --"
 cd ${GIT_DIR}/deephaven-core
 OLD_JAVA_HOME="${JAVA_HOME}"
 export JAVA_HOME=/usr/lib/jvm/${BUILD_JAVA}
+
+echo "org.gradle.daemon=false" >> gradle.properties
 ./gradlew outputVersion server-jetty-app:assemble py-server:assemble
-title "-- Finished Assembly Build --"
+
 export DEEPHAVEN_VERSION=$(cat build/version)
-title "-- Deephaven Version ${DEEPHAVEN_VERSION}--"
 export JAVA_HOME="${OLD_JAVA_HOME}"
-title "-- Restored Java Home --"
 
 title "-- Building Deephaven Docker Image --"
 cd ${GIT_DIR}/deephaven-server-docker

--- a/.github/scripts/build-docker-image-remote.sh
+++ b/.github/scripts/build-docker-image-remote.sh
@@ -11,6 +11,7 @@ GIT_DIR=/root/git
 DEEPHAVEN_DIR=/root/deephaven
 DOCKER_IMG=$1
 BRANCH_DELIM="::"
+BUILD_JAVA=temurin-11-jdk-amd64
 
 if [ ! -d "${DEEPHAVEN_DIR}" ]; then
   echo "$0: Missing one or more Benchmark setup directories"
@@ -56,7 +57,7 @@ git checkout main
 title "-- Assembling Python Deephaven Core Server --"
 cd ${GIT_DIR}/deephaven-core
 OLD_JAVA_HOME="${JAVA_HOME}"
-export JAVA_HOME=/usr/lib/jvm/${JAVA}
+export JAVA_HOME=/usr/lib/jvm/${BUILD_JAVA}
 ./gradlew outputVersion server-jetty-app:assemble py-server:assemble
 export DEEPHAVEN_VERSION=$(cat build/version)
 export JAVA_HOME="${OLD_JAVA_HOME}"

--- a/.github/scripts/build-docker-image-remote.sh
+++ b/.github/scripts/build-docker-image-remote.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Build a local docker image on the remote side if needed
+# Ensure the docker image is running in the Deephaven directory
+
+HOST=`hostname`
+GIT_DIR=/root/git
+DEEPHAVEN_DIR=/root/deephaven
+DOCKER_IMG=$1
+BRANCH_DELIM="::"
+
+if [ ! -d "${DEEPHAVEN_DIR}" ]; then
+  echo "$0: Missing one or more Benchmark setup directories"
+  exit 1
+fi
+
+if [[ $# != 1 ]]; then
+  echo "$0: Missing docker image/branch argument"
+  exit 1
+fi
+
+title () { echo; echo $1; }
+
+title "- Setting up Remote Docker Image on ${HOST} -"
+
+if [[ ${DOCKER_IMG} != *"${BRANCH_DELIM}"* ]]; then
+  echo "DOCKER_IMG=ghcr.io/deephaven/server:${DOCKER_IMG}" > .env
+  docker compose pull
+  title "-- Starting Deephaven and Redpanda --"
+  docker compose up -d
+  exit 0
+fi
+
+readarray -d "${BRANCH_DELIM}" -t splitarr <<< "${DOCKER_IMG}"
+OWNER=${splitarr[0]}
+BRANCH_NAME=${splitarr[1]}
+
+title "-- Cloning deephaven-core --"
+cd ${GIT_DIR}
+rm -rf deephaven-core 
+git clone git@github.com:${OWNER}/deephaven-core.git
+cd deephaven-core
+git checkout ${BRANCH_NAME}
+
+title "-- Cloning deephaven-server-docker --"
+cd ${GIT_DIR}
+rm -rf deephaven-server-docker
+git clone git@github.com:deephaven/deephaven-server-docker.git
+cd deephaven-server-docker
+git checkout main
+
+title "-- Assembling Python Deephaven Core Server --"
+cd ${GIT_DIR}/deephaven-core
+OLD_JAVA_HOME="${JAVA_HOME}"
+export JAVA_HOME=/usr/lib/jvm/${JAVA}
+./gradlew outputVersion server-jetty-app:assemble py-server:assemble
+export DEEPHAVEN_VERSION=$(cat build/version)
+export JAVA_HOME="${OLD_JAVA_HOME}"
+
+title "-- Building Deephaven Docker Image --"
+cd ${GIT_DIR}/deephaven-server-docker
+cp ${GIT_DIR}/deephaven-core/server/jetty-app/build/distributions/server-jetty-*.tar contexts/server/
+cp ${GIT_DIR}/deephaven-core/server/jetty-app/build/distributions/server-jetty-*.tar contexts/server-slim/
+cp ${GIT_DIR}/deephaven-core/py/server/build/wheel/deephaven_core-*-py3-none-any.whl contexts/server/
+
+export DEEPHAVEN_SOURCES=custom
+export DEEPHAVEN_CORE_WHEEL=$(find . -type f -name "*.whl" | xargs -n 1 basename)
+export TAG=benchmark-local
+
+echo "DEEPHAVEN_VERSION: ${DEEPHAVEN_VERSION}"
+echo "DEEPHAVEN_CORE_WHEEL: ${DEEPHAVEN_CORE_WHEEL}"
+docker buildx bake -f server.hcl
+
+title "-- Starting Deephaven and Redpanda --"
+echo "DOCKER_IMG=deephaven/server:benchmark-local" > .env
+docker compose up -d
+
+
+

--- a/.github/scripts/build-docker-image-remote.sh
+++ b/.github/scripts/build-docker-image-remote.sh
@@ -56,7 +56,7 @@ git checkout main
 
 title "-- Assembling Python Deephaven Core Server --"
 cd ${GIT_DIR}/deephaven-core
-OLD_JAVA_HOME="${JAVA_HOME}"
+OLD_JAVA_HOME="${JAVA_HOME:-}"
 export JAVA_HOME=/usr/lib/jvm/${JAVA}
 ./gradlew outputVersion server-jetty-app:assemble py-server:assemble
 export DEEPHAVEN_VERSION=$(cat build/version)

--- a/.github/scripts/build-server-distribution-remote.sh
+++ b/.github/scripts/build-server-distribution-remote.sh
@@ -26,17 +26,6 @@ fi
 
 title () { echo; echo $1; }
 
-title "- Setting up Remote Docker Image on ${HOST} -"
-
-if [[ ${DOCKER_IMG} != *"${BRANCH_DELIM}"* ]]; then
-  cd ${DEEPHAVEN_DIR}
-  echo "DOCKER_IMG=ghcr.io/deephaven/server:${DOCKER_IMG}" > .env
-  docker compose pull
-  title "-- Starting Deephaven and Redpanda --"
-  docker compose up -d
-  exit 0
-fi
-
 readarray -d "${BRANCH_DELIM}" -t splitarr <<< "${DOCKER_IMG}"
 OWNER=${splitarr[0]}
 BRANCH_NAME=${splitarr[1]}

--- a/.github/scripts/build-server-distribution-remote.sh
+++ b/.github/scripts/build-server-distribution-remote.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+# Assemble the Deephaven server artifacts on the remote side if needed
+# The supplied argument can be an image name or <owner>::<branch>
+# Ensure that the artifacts and Deephaven version are available in standard directories
+
+HOST=`hostname`
+GIT_DIR=/root/git
+DEEPHAVEN_DIR=/root/deephaven
+DOCKER_IMG=$1
+BRANCH_DELIM="::"
+BUILD_JAVA=temurin-11-jdk-amd64
+
+if [ ! -d "${DEEPHAVEN_DIR}" ]; then
+  echo "$0: Missing one or more Benchmark setup directories"
+  exit 1
+fi
+
+if [[ $# != 1 ]]; then
+  echo "$0: Missing docker image/branch argument"
+  exit 1
+fi
+
+title () { echo; echo $1; }
+
+title "- Setting up Remote Docker Image on ${HOST} -"
+
+if [[ ${DOCKER_IMG} != *"${BRANCH_DELIM}"* ]]; then
+  cd ${DEEPHAVEN_DIR}
+  echo "DOCKER_IMG=ghcr.io/deephaven/server:${DOCKER_IMG}" > .env
+  docker compose pull
+  title "-- Starting Deephaven and Redpanda --"
+  docker compose up -d
+  exit 0
+fi
+
+readarray -d "${BRANCH_DELIM}" -t splitarr <<< "${DOCKER_IMG}"
+OWNER=${splitarr[0]}
+BRANCH_NAME=${splitarr[1]}
+
+title "-- Cloning deephaven-core --"
+cd ${GIT_DIR}
+rm -rf deephaven-core 
+git clone https://github.com/${OWNER}/deephaven-core.git
+cd deephaven-core
+git checkout ${BRANCH_NAME}
+
+title "-- Cloning deephaven-server-docker --"
+cd ${GIT_DIR}
+rm -rf deephaven-server-docker
+git clone https://github.com/deephaven/deephaven-server-docker.git
+cd deephaven-server-docker
+git checkout main
+
+title "-- Assembling Python Deephaven Core Server --"
+cd ${GIT_DIR}/deephaven-core
+OLD_JAVA_HOME="${JAVA_HOME}"
+export JAVA_HOME=/usr/lib/jvm/${BUILD_JAVA}
+
+echo "org.gradle.daemon=false" >> gradle.properties
+./gradlew outputVersion server-jetty-app:assemble py-server:assemble
+
+

--- a/.github/scripts/fetch-results-local.sh
+++ b/.github/scripts/fetch-results-local.sh
@@ -22,6 +22,7 @@ fi
 # Pull results from the benchmark server
 scp -r ${USER}@${HOST}:${RUN_DIR}/results .
 scp -r ${USER}@${HOST}:${RUN_DIR}/logs .
+scp -r ${USER}@${HOST}:${RUN_DIR}/*.jar .
 
 # If the RUN_TYPE is adhoc, userfy the destination directory
 DEST_DIR=${RUN_TYPE}

--- a/.github/scripts/manage-deephaven-remote.sh
+++ b/.github/scripts/manage-deephaven-remote.sh
@@ -9,8 +9,8 @@ set -o pipefail
 
 HOST=`hostname`
 DEEPHAVEN_DIR=/root/deephaven
-DOCKER_IMG=$1
-DIRECTIVE=$2
+DIRECTIVE=$1
+DOCKER_IMG=$2
 BRANCH_DELIM="::"
 
 if [ ! -d "${DEEPHAVEN_DIR}" ]; then

--- a/.github/scripts/manage-deephaven-remote.sh
+++ b/.github/scripts/manage-deephaven-remote.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+# Start or Stop a Deephaven image based on the given directive and image/branch name
+# The directives argument can be start or stop
+# The supplied image argument can be an image name or <owner>::<branch>
+
+HOST=`hostname`
+DEEPHAVEN_DIR=/root/deephaven
+DOCKER_IMG=$1
+DIRECTIVE=$2
+BRANCH_DELIM="::"
+
+if [ ! -d "${DEEPHAVEN_DIR}" ]; then
+  echo "$0: Missing one or more Benchmark setup directories"
+  exit 1
+fi
+
+if [[ $# != 2 ]]; then
+  echo "$0: Missing docker directive or image/branch argument"
+  exit 1
+fi
+
+title () { echo; echo $1; }
+
+title "- Setting up Remote Docker Image on ${HOST} -"
+
+cd ${DEEPHAVEN_DIR}
+
+if [[ ${DOCKER_IMG} != *"${BRANCH_DELIM}"* ]]; then
+  echo "DOCKER_IMG=ghcr.io/deephaven/server:${DOCKER_IMG}" > .env
+  docker compose pull
+else 
+  echo "DOCKER_IMG=deephaven/server:benchmark-local" > .env
+fi
+
+if [[ ${DIRECTIVE} == 'start' ]]; then
+  docker compose up -d
+fi
+
+if [[ ${DIRECTIVE} == 'stop' ]]; then
+  docker compose down
+fi
+

--- a/.github/scripts/run-publish-local.sh
+++ b/.github/scripts/run-publish-local.sh
@@ -27,6 +27,8 @@ rm -f ${RUN_DIR}/deephaven-benchmark*-tests.jar
 cat ${BENCH_PROPS_PATH} | sed 's|${slackToken}|'"${SLACK_TOKEN}|g" | sed 's|${slackChannel}'"|${SLACK_CHANNEL}|g" > ${RUN_DIR}/${BENCH_PROPS_NAME}
 
 cd ${DEEPHAVEN_DIR}
+cp ${GIT_DIR}/.github/resources/integration-docker-compose.yml docker-compose.yml
+docker compose pull
 sudo docker compose down
 sudo docker compose up -d
 sleep 10

--- a/.github/scripts/run-publish-local.sh
+++ b/.github/scripts/run-publish-local.sh
@@ -22,7 +22,7 @@ BENCH_PROPS_NAME=${RUN_TYPE}-scale-benchmark.properties
 BENCH_PROPS_PATH=${GIT_DIR}/.github/resources/${BENCH_PROPS_NAME}
 
 mkdir -p ${RUN_DIR}
-cp ${GIT_DIR}/target/deephaven-benchmark-*.jar ${RUN_DIR}/
+cp ./deephaven-benchmark-*.jar ${RUN_DIR}/
 rm -f ${RUN_DIR}/deephaven-benchmark*-tests.jar
 cat ${BENCH_PROPS_PATH} | sed 's|${slackToken}|'"${SLACK_TOKEN}|g" | sed 's|${slackChannel}'"|${SLACK_CHANNEL}|g" > ${RUN_DIR}/${BENCH_PROPS_NAME}
 

--- a/.github/scripts/setup-test-server-remote.sh
+++ b/.github/scripts/setup-test-server-remote.sh
@@ -75,16 +75,10 @@ docker images -a -q | xargs --no-run-if-empty -n 1 docker rmi
 docker system prune --volumes --force
 rm -rf ${DEEPHAVEN_DIR}
 
-title "-- Installing Deephaven and Redpanda --"
+title "-- Staging Docker Resources --"
 mkdir -p ${DEEPHAVEN_DIR}
 cd ${DEEPHAVEN_DIR}
 cp ${GIT_DIR}/benchmark/.github/resources/${RUN_TYPE}-benchmark-docker-compose.yml docker-compose.yml
-echo "DOCKER_IMG=${DOCKER_IMG}" > .env
-docker compose pull
-
-title "-- Starting Deephaven and Redpanda --"
-docker compose up -d
-
 
 
 

--- a/.github/scripts/setup-test-server-remote.sh
+++ b/.github/scripts/setup-test-server-remote.sh
@@ -68,9 +68,9 @@ fi
 
 title "-- Removing Git Benchmark Repositories --"
 rm -rf ${GIT_DIR}
+mkdir -p ${GIT_DIR}
 
 title "-- Clone Git Benchmark Repository ${GIT_REPO} --"
-mkdir -p ${GIT_DIR}
 cd ${GIT_DIR}
 git clone https://github.com/${GIT_REPO}.git
 cd benchmark
@@ -79,7 +79,7 @@ title "-- Clone Git Benchmark Branch ${GIT_BRANCH} --"
 git checkout ${GIT_BRANCH}
 
 title "-- Stopping and Removing Docker Installations --"
-docker ps -a -q | xargs --no-run-if-empty -n 1 docker stop
+docker ps -a -q | xargs --no-run-if-empty -n 1 docker kill
 docker ps -a -q | xargs --no-run-if-empty -n 1 docker rm --force
 docker images -a -q | xargs --no-run-if-empty -n 1 docker rmi --force
 docker system prune --volumes --force

--- a/.github/scripts/setup-test-server-remote.sh
+++ b/.github/scripts/setup-test-server-remote.sh
@@ -80,8 +80,8 @@ git checkout ${GIT_BRANCH}
 
 title "-- Stopping and Removing Docker Installations --"
 docker ps -a -q | xargs --no-run-if-empty -n 1 docker stop
-docker ps -a -q | xargs --no-run-if-empty -n 1 docker rm
-docker images -a -q | xargs --no-run-if-empty -n 1 docker rmi
+docker ps -a -q | xargs --no-run-if-empty -n 1 docker rm --force
+docker images -a -q | xargs --no-run-if-empty -n 1 docker rmi --force
 docker system prune --volumes --force
 rm -rf ${DEEPHAVEN_DIR}
 

--- a/.github/scripts/setup-test-server-remote.sh
+++ b/.github/scripts/setup-test-server-remote.sh
@@ -30,7 +30,8 @@ title "- Setting Up Remote Benchmark Testing on ${HOST} -"
 
 title "-- Adding OS Applications --"
 UPDATED=$(update-alternatives --list java | grep -i temurin; echo $?)
-if [[ %{UPDATED} != 0 ]]; then
+if [[ ${UPDATED} != 0 ]]; then
+  title "-- Adding Adoptium to APT registry --"
   apt install -y wget apt-transport-https gpg
   wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
   echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
@@ -38,13 +39,13 @@ if [[ %{UPDATED} != 0 ]]; then
 fi
 
 title "-- Installing JVMs --"
-apt install temurin-11-jdk
-apt install temurin-21-jdk
+apt -y install temurin-11-jdk
+apt -y install temurin-21-jdk
 # Look at installed packages:  dpkg --list | grep jdk
 # Configure default java:  update-alternatives --config java
 
 title "-- Installing Maven --"
-apt install maven
+apt -y install maven
 
 title "-- Installing Docker --"
 command_exists() {

--- a/.github/scripts/setup-test-server-remote.sh
+++ b/.github/scripts/setup-test-server-remote.sh
@@ -29,7 +29,13 @@ title () { echo; echo $1; }
 title "- Setting Up Remote Benchmark Testing on ${HOST} -"
 
 title "-- Adding OS Applications --"
-apt update
+UPDATED=$(update-alternatives --list java | grep -i temurin; echo $?)
+if [[ %{UPDATED} != 0 ]]; then
+  apt install -y wget apt-transport-https gpg
+  wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add -
+  echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
+  apt update
+fi
 
 title "-- Installing JVMs --"
 apt install temurin-11-jdk

--- a/.github/scripts/setup-test-server-remote.sh
+++ b/.github/scripts/setup-test-server-remote.sh
@@ -79,7 +79,7 @@ title "-- Clone Git Benchmark Branch ${GIT_BRANCH} --"
 git checkout ${GIT_BRANCH}
 
 title "-- Stopping Docker Containers --"
-docker ps -a -q | xargs --no-run-if-empty -n 1 docker stop --force
+docker ps -a -q | xargs --no-run-if-empty -n 1 docker kill
 
 title "-- Removing Docker Containers --"
 docker ps -a -q | xargs --no-run-if-empty -n 1 docker rm --force

--- a/.github/scripts/setup-test-server-remote.sh
+++ b/.github/scripts/setup-test-server-remote.sh
@@ -78,10 +78,16 @@ cd benchmark
 title "-- Clone Git Benchmark Branch ${GIT_BRANCH} --"
 git checkout ${GIT_BRANCH}
 
-title "-- Stopping and Removing Docker Installations --"
-docker ps -a -q | xargs --no-run-if-empty -n 1 docker kill
+title "-- Stopping Docker Containers --"
+docker ps -a -q | xargs --no-run-if-empty -n 1 docker stop --force
+
+title "-- Removing Docker Containers --"
 docker ps -a -q | xargs --no-run-if-empty -n 1 docker rm --force
+
+title "-- Removing Docker Images --"
 docker images -a -q | xargs --no-run-if-empty -n 1 docker rmi --force
+
+title "-- Pruning Docker Volumes --"
 docker system prune --volumes --force
 rm -rf ${DEEPHAVEN_DIR}
 

--- a/.github/scripts/setup-test-server-remote.sh
+++ b/.github/scripts/setup-test-server-remote.sh
@@ -31,8 +31,11 @@ title "- Setting Up Remote Benchmark Testing on ${HOST} -"
 title "-- Adding OS Applications --"
 apt update
 
-title "-- Installing JDK 21 --"
-apt install openjdk-21-jre-headless
+title "-- Installing JVMs --"
+apt install temurin-11-jdk
+apt install temurin-21-jdk
+# Look at installed packages:  dpkg --list | grep jdk
+# Configure default java:  update-alternatives --config java
 
 title "-- Installing Maven --"
 apt install maven

--- a/.github/workflows/adhoc-remote-benchmarks.yml
+++ b/.github/workflows/adhoc-remote-benchmarks.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
    inputs:
      docker_image:
-       description: 'Docker Image Name'
+       description: 'Docker Image Name or DH Core Branch'
        required: true
        default: 'edge'
        type: string

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -44,6 +44,7 @@ jobs:
       TEST_RGX: ${{inputs.test_class_regex}}
       ROW_CNT: ${{inputs.scale_row_count}}
       ACTOR: ${{github.actor}}
+      IS_IMAGE_BUILD: contains(${DOCKER_IMG}, "::")
 
     steps:
     - uses: actions/checkout@v3
@@ -63,9 +64,15 @@ jobs:
       run: |
         ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} setup-test-server-remote ${REPO} ${BRANCH} ${RUN_TYPE} "${DOCKER_IMG}"
 
-    - name: Run Remote Docker Image Build
+    - name: Run Remote Server Distribution Build
+      if: ${IS_IMAGE_BUILD}
       run: |
-        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-docker-image-remote "${DOCKER_IMG}"
+        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-server-distribution-remote "${DOCKER_IMG}"
+        
+    - name: Run Remote Docker Image Build
+      if: ${IS_IMAGE_BUILD}
+      run: |
+        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-docker-image-remote
 
     - name: Run Remote Benchmark Artifact Build
       run: |

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -44,7 +44,7 @@ jobs:
       TEST_RGX: ${{inputs.test_class_regex}}
       ROW_CNT: ${{inputs.scale_row_count}}
       ACTOR: ${{github.actor}}
-      IS_IMAGE_BUILD: contains(${DOCKER_IMG}, "::")
+      IS_IMAGE_BUILD: ${{ contains(env.DOCKER_IMG, "::") }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -54,7 +54,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
         
-    - name: Setup Local and Remote Scripts
+    - name: Setup Local Scripts
       run: |
         sudo chmod +x ${SD}/*
         ${SD}/setup-ssh-local.sh ${HOST} "${{secrets.BENCHMARK_KEY}}"

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -65,12 +65,12 @@ jobs:
         ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} setup-test-server-remote ${REPO} ${BRANCH} ${RUN_TYPE} "${DOCKER_IMG}"
 
     - name: Run Remote Server Distribution Build
-      if: ${IS_IMAGE_BUILD}
+      if: ${{.env.IS_IMAGE_BUILD}}
       run: |
         ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-server-distribution-remote "${DOCKER_IMG}"
         
     - name: Run Remote Docker Image Build
-      if: ${IS_IMAGE_BUILD}
+      if: ${{.env.IS_IMAGE_BUILD}}
       run: |
         ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-docker-image-remote
 

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -44,7 +44,6 @@ jobs:
       TEST_RGX: ${{inputs.test_class_regex}}
       ROW_CNT: ${{inputs.scale_row_count}}
       ACTOR: ${{github.actor}}
-      IS_IMAGE_BUILD: ${{ contains(inputs.docker_image, '::') }}
 
     steps:
     - uses: actions/checkout@v3
@@ -65,12 +64,12 @@ jobs:
         ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} setup-test-server-remote ${REPO} ${BRANCH} ${RUN_TYPE} "${DOCKER_IMG}"
 
     - name: Run Remote Server Distribution Build
-      if: ${{env.IS_IMAGE_BUILD}}
+      if: ${{ contains(env.DOCKER_IMG, '::') }}
       run: |
         ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-server-distribution-remote "${DOCKER_IMG}"
         
     - name: Run Remote Docker Image Build
-      if: ${{env.IS_IMAGE_BUILD}}
+      if: ${{ contains(env.DOCKER_IMG, '::') }}
       run: |
         ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-docker-image-remote
 

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -53,21 +53,7 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
-
-    - name: Docker Pull Deephaven and Redpanda
-      run: |
-        cp .github/resources/${RUN_TYPE}-benchmark-docker-compose.yml docker-compose.yml
-        echo "DOCKER_IMG=${DOCKER_IMG}" > .env
-        docker compose pull
-
-    - name: Docker Up Deephaven and Redpanda
-      run: docker compose up -d
-
-    - name: Build with Maven
-      run: |
-        mvn -B verify --file pom.xml
-        rm -rf results
-    
+        
     - name: Setup Local and Remote Scripts
       run: |
         sudo chmod +x ${SD}/*
@@ -76,6 +62,10 @@ jobs:
     - name: Run Remote Test Server Setup
       run: |
         ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} setup-test-server-remote ${REPO} ${BRANCH} ${RUN_TYPE} "${DOCKER_IMG}"
+
+    - name: Run Remote Docker Image Build
+      run: |
+        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-dokcer-image-remote ${DOCKER_IMG}
 
     - name: Run Remote Benchmark Artifact Build
       run: |

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Run Remote Docker Image Build
       run: |
-        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-dokcer-image-remote ${DOCKER_IMG}
+        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-docker-image-remote ${DOCKER_IMG}
 
     - name: Run Remote Benchmark Artifact Build
       run: |

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -44,7 +44,7 @@ jobs:
       TEST_RGX: ${{inputs.test_class_regex}}
       ROW_CNT: ${{inputs.scale_row_count}}
       ACTOR: ${{github.actor}}
-      IS_IMAGE_BUILD: ${{ contains(env.DOCKER_IMG, "::") }}
+      IS_IMAGE_BUILD: ${{ contains(inputs.docker_image, "::") }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -65,12 +65,12 @@ jobs:
         ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} setup-test-server-remote ${REPO} ${BRANCH} ${RUN_TYPE} "${DOCKER_IMG}"
 
     - name: Run Remote Server Distribution Build
-      if: ${{.env.IS_IMAGE_BUILD}}
+      if: ${{env.IS_IMAGE_BUILD}}
       run: |
         ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-server-distribution-remote "${DOCKER_IMG}"
         
     - name: Run Remote Docker Image Build
-      if: ${{.env.IS_IMAGE_BUILD}}
+      if: ${{env.IS_IMAGE_BUILD}}
       run: |
         ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-docker-image-remote
 

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Run Remote Docker Image Build
       run: |
-        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-docker-image-remote ${DOCKER_IMG}
+        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-docker-image-remote "${DOCKER_IMG}"
 
     - name: Run Remote Benchmark Artifact Build
       run: |

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -73,6 +73,10 @@ jobs:
       run: |
         ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-docker-image-remote
 
+    - name: Start Remote Remote Deephaven Server
+      run: | 
+        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} manage-deephaven-remote start "${DOCKER_IMG}"
+
     - name: Run Remote Benchmark Artifact Build
       run: |
         ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} build-benchmark-artifact-remote

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -44,7 +44,7 @@ jobs:
       TEST_RGX: ${{inputs.test_class_regex}}
       ROW_CNT: ${{inputs.scale_row_count}}
       ACTOR: ${{github.actor}}
-      IS_IMAGE_BUILD: ${{ contains(inputs.docker_image, "::") }}
+      IS_IMAGE_BUILD: ${{ contains(inputs.docker_image, '::') }}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
- Improved Adhoc Benchmarking by allowing Deephaven-Core <owner>::<branch> to be specified as well as existing images
- Use existing Workflow UI Image field for either option (image or branch)
- Build image in the case where <owner>::<branch> is specified
- Run adhoc against image, whether supplied or built, and publish results to GCloud Benchmark bucket as usual
- Removed "mvn verify" from the runner-side workflow, since it was happening twice
  - Pull jar artifacts from the Benchmark test server instead of from the GH runner
- Added setup for `update-alternatives` to support multiple versions of Temurin Java JDK
- Added `--force` and `kill` to fix an issue with deleting referenced containers