### PR TITLE
Checkout correct adhoc branch

### DIFF
--- a/.github/scripts/build-server-distribution-remote.sh
+++ b/.github/scripts/build-server-distribution-remote.sh
@@ -39,7 +39,7 @@ git clone -b ${BRANCH_NAME} --single-branch https://github.com/${OWNER}/deephave
 title "-- Cloning deephaven-server-docker --"
 cd ${GIT_DIR}
 rm -rf deephaven-server-docker
-git clone -b main --single-branch https://github.com/${OWNER}/deephaven-server-docker.git
+git clone -b main --single-branch https://github.com/deephaven/deephaven-server-docker.git
 
 title "-- Assembling Python Deephaven Core Server --"
 cd ${GIT_DIR}/deephaven-core
@@ -47,5 +47,6 @@ export JAVA_HOME=/usr/lib/jvm/${BUILD_JAVA}
 
 echo "org.gradle.daemon=false" >> gradle.properties
 ./gradlew outputVersion server-jetty-app:assemble py-server:assemble
+
 
 

--- a/.github/scripts/build-server-distribution-remote.sh
+++ b/.github/scripts/build-server-distribution-remote.sh
@@ -26,27 +26,23 @@ fi
 
 title () { echo; echo $1; }
 
-readarray -d "${BRANCH_DELIM}" -t splitarr <<< "${DOCKER_IMG}"
-OWNER=${splitarr[0]}
-BRANCH_NAME=${splitarr[1]}
+OWNER=$(sed 's/'"${BRANCH_DELIM}"'.*//g' <<< "${DOCKER_IMG}")
+BRANCH_NAME=$(sed 's/.*'"${BRANCH_DELIM}"'//g' <<< "${DOCKER_IMG}")
+echo "OWNER: ${OWNER}"
+echo "BRANCH: ${BRANCH_NAME}"
 
 title "-- Cloning deephaven-core --"
 cd ${GIT_DIR}
-rm -rf deephaven-core 
-git clone https://github.com/${OWNER}/deephaven-core.git
-cd deephaven-core
-git checkout ${BRANCH_NAME}
+rm -rf deephaven-core
+git clone -b ${BRANCH_NAME} --single-branch https://github.com/${OWNER}/deephaven-core.git
 
 title "-- Cloning deephaven-server-docker --"
 cd ${GIT_DIR}
 rm -rf deephaven-server-docker
-git clone https://github.com/deephaven/deephaven-server-docker.git
-cd deephaven-server-docker
-git checkout main
+git clone -b main --single-branch https://github.com/${OWNER}/deephaven-server-docker.git
 
 title "-- Assembling Python Deephaven Core Server --"
 cd ${GIT_DIR}/deephaven-core
-OLD_JAVA_HOME="${JAVA_HOME}"
 export JAVA_HOME=/usr/lib/jvm/${BUILD_JAVA}
 
 echo "org.gradle.daemon=false" >> gradle.properties

--- a/.github/scripts/setup-test-server-remote.sh
+++ b/.github/scripts/setup-test-server-remote.sh
@@ -79,7 +79,7 @@ title "-- Clone Git Benchmark Branch ${GIT_BRANCH} --"
 git checkout ${GIT_BRANCH}
 
 title "-- Stopping Docker Containers --"
-docker ps -a -q | xargs --no-run-if-empty -n 1 docker kill
+docker ps -q | xargs --no-run-if-empty -n 1 docker kill
 
 title "-- Removing Docker Containers --"
 docker ps -a -q | xargs --no-run-if-empty -n 1 docker rm --force

--- a/src/it/java/io/deephaven/benchmark/tests/internal/metrics/MetricsCollectionTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/metrics/MetricsCollectionTest.java
@@ -11,6 +11,7 @@ import io.deephaven.benchmark.api.Bench;
  * Test to see what metrics are available in the remote Deephaven Server. Note. These tests should pass when DH is
  * either JVM 17 or JVM 21
  */
+@Disabled
 public class MetricsCollectionTest {
     final Bench api = Bench.create(this);
 

--- a/src/it/java/io/deephaven/benchmark/tests/internal/metrics/MetricsCollectionTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/metrics/MetricsCollectionTest.java
@@ -9,9 +9,8 @@ import io.deephaven.benchmark.api.Bench;
 
 /**
  * Test to see what metrics are available in the remote Deephaven Server. Note. These tests should pass when DH is
- * either JVM 17 or JVM 21
+ * JVM 17+
  */
-@Disabled
 public class MetricsCollectionTest {
     final Bench api = Bench.create(this);
 
@@ -29,7 +28,7 @@ public class MetricsCollectionTest {
             assertEquals("timestamp, origin, category, type, name, value, note", formatCols(table.getColumnNames()),
                     "Wrong column names");
             int rowCount = table.getRowCount();
-            assertTrue(rowCount == 21 || rowCount == 23, "Wrong row count. Got " + rowCount);
+            assertTrue(rowCount > 20, "Wrong row count. Got " + rowCount);
             assertEquals("ClassLoadingImpl", table.getValue(0, "category"), "Wrong bean name");
             assertEquals("TotalLoadedClassCount", table.getValue(0, "name"), "Wrong ");
             assertTrue(table.getValue(3, "value").toString()
@@ -52,7 +51,7 @@ public class MetricsCollectionTest {
             assertEquals("timestamp, origin, category, type, name, value, note", formatCols(table.getColumnNames()),
                     "Wrong column names");
             int rowCount = table.getRowCount();
-            assertTrue(rowCount == 42 || rowCount == 46, "Wrong row count. Got " + rowCount);
+            assertTrue(rowCount > 40, "Wrong row count. Got " + rowCount);
         }).execute();
     }
 
@@ -68,7 +67,7 @@ public class MetricsCollectionTest {
 
         api.query(query).fetchAfter("mymetrics", table -> {
             int rowCount = table.getRowCount();
-            assertTrue(rowCount == 21 || rowCount == 23, "Wrong row count. Got " + rowCount);
+            assertTrue(rowCount > 20, "Wrong row count. Got " + rowCount);
             api.metrics().add(table);
         }).execute();
         api.close();


### PR DESCRIPTION
- Fixed the parsing so that OWNER and BRANCH_NAME variables are set correctly.
- Changed to doing single branch clones. (Somewhat faster than clone-checkout
- Fixed an issue where `docker kill` complains about killing non-running containers
- Change metrics collection integration tests to not be so sensitive metric counts from different JVMs