### PR TITLE
Remove Docker Compose Version Tag From Example

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -24,8 +24,6 @@ and setup tips.
 
 For Benchmark setup, the following docker-compose.yml file is useful.
 ````
-version: "3.4"
-
 services:
   deephaven:
     image: ghcr.io/deephaven/server:edge


### PR DESCRIPTION
The "version" attribute in docker-compose.yml files is no longer appropriate for compose v2 and results in a warning about obsolescence.  Remove it from the example in _GettingStarted.md_ doc.

References:
- https://github.com/deephaven/deephaven-core/pull/5322