### PR TITLE
Added benchmarks for scalar UDFs with no Hints

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/formula/UserFormulaTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/formula/UserFormulaTest.java
@@ -18,16 +18,17 @@ public class UserFormulaTest {
 
     @BeforeEach
     void setup() {
+        runner.setRowFactor(1);
         runner.tables("source");
+        runner.setScaleFactors(1, 1);
     }
 
     @Test
     void udfDoubleArrayToDoubleNoHints() {
-        runner.setScaleFactors(1, 1);
         var setup = """
         def f(arr):
             return arr[0]
-        source = source.update(['num1 = repeat(num1,5)'])
+        source = source.update(['num1=repeat(num1,5)'])
         """;
         runner.addSetupQuery(setup);
         var q = "source.select(['num1=(double)f(num1)'])";
@@ -36,7 +37,6 @@ public class UserFormulaTest {
 
     @Test
     void udfDoubleToDoubleArrayNoHints() {
-        runner.setScaleFactors(1, 1);
         var setup = """
         def f(num):
             return jpy.array('double', [num] * 5)
@@ -48,7 +48,6 @@ public class UserFormulaTest {
 
     @Test
     void udf2DoublesToDoubleNoHints() {
-        runner.setScaleFactors(1, 1);
         var setup = """
         def f(num1, num2):
             return num1 + num2
@@ -58,10 +57,21 @@ public class UserFormulaTest {
         runner.test("UDF- 2 Doubles to Double No Hints", q, "num1", "num2");
     }
 
+    @Test
+    void udf2DoublesToDoublePythonHints() {
+        runner.setScaleFactors(3, 3);
+        var setup = """
+        def f(num1: float, num2: float) -> float:
+            return num1 + num2
+        """;
+        runner.addSetupQuery(setup);
+        var q = "source.select(['num1=f(num1, num2)'])";
+        runner.test("UDF- 2 Doubles to Double Python Hints", q, "num1", "num2");
+    }
+
 
     @Test
     void udfDoubleArrayToDoubleNumpyHints() {
-        runner.setScaleFactors(1, 1);
         var setup = """
         def f(arr: npt.NDArray[np.float64]) -> np.float64:
             return arr[0]
@@ -74,7 +84,6 @@ public class UserFormulaTest {
 
     @Test
     void udfDoubleToDoubleArrayNumpyHints() {
-        runner.setScaleFactors(1, 1);
         var setup = """
         def f(num: np.float64) -> npt.NDArray[np.float64]:
             return np.repeat(num,5)
@@ -86,14 +95,13 @@ public class UserFormulaTest {
 
     @Test
     void udf2DoublesToDoubleNumpyHints() {
-        runner.setScaleFactors(1, 1);
         var setup = """
         def f(num1: np.float64, num2: np.float64) -> np.float64:
             return num1 + num2
         """;
         runner.addSetupQuery(setup);
         var q = "source.select(['num1=f(num1, num2)'])";
-        runner.test("UDF- 2 Ints to Int Numpy Hints", q, "num1", "num2");
+        runner.test("UDF- 2 Doubles to Double Numpy Hints", q, "num1", "num2");
     }
 
 }


### PR DESCRIPTION
- Added scalar to scalar UDF tests that use Python built-ins
  - There is no support for array type hints (`array.array` causes in "unsupported" error, because there is no scalar type 
- Fixed an existing benchmark's name (we are using all doubles, not ints)