### PR TITLE
Rescale Inline Formula Benchmarks

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/compare/join/InnerJoinTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/compare/join/InnerJoinTest.java
@@ -23,7 +23,7 @@ public class InnerJoinTest {
     @Test
     @Order(1)
     public void deephavenInnerJoin() {
-        runner.initDeephaven(2, "source", "right", "int1M", "str250", "r_int1M", "r_str250");
+        runner.initDeephaven(4, "source", "right", "int1M", "str250", "r_int1M", "r_str250");
         var setup = "from deephaven.parquet import read";
         var op = """
         source = read('/data/source.parquet').select()

--- a/src/it/java/io/deephaven/benchmark/tests/compare/join/InnerJoinTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/compare/join/InnerJoinTest.java
@@ -23,7 +23,7 @@ public class InnerJoinTest {
     @Test
     @Order(1)
     public void deephavenInnerJoin() {
-        runner.initDeephaven(4, "source", "right", "int1M", "str250", "r_int1M", "r_str250");
+        runner.initDeephaven(2, "source", "right", "int1M", "str250", "r_int1M", "r_str250");
         var setup = "from deephaven.parquet import read";
         var op = """
         source = read('/data/source.parquet').select()

--- a/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
@@ -21,40 +21,40 @@ public class InlineFormulaTest {
         runner.setScaleFactors(staticFactor, incFactor);
     }
 
-    @Test
-    void select1Calc1ColFormula() {
-        setup(3, 43, 18);
-        var q = "source.select(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-        runner.test("Select-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-    }
-
-    @Test
-    void select1Calc2ColsFormula() {
-        setup(3, 30, 12);
-        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-        runner.test("Select-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-    }
-
-    @Test
-    void select2Calcs2ColsFormula() {
-        setup(2, 35, 17);
-        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
-        runner.test("Select-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
-    }
-
-    @Test
-    void update1Calc1ColsFormula() {
-        setup(3, 55, 40);
-        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-        runner.test("Update-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-    }
-
-    @Test
-    void update1Calc2ColsFormula() {
-        setup(3, 45, 30);
-        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-        runner.test("Update-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-    }
+//    @Test
+//    void select1Calc1ColFormula() {
+//        setup(3, 43, 18);
+//        var q = "source.select(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+//        runner.test("Select-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+//    }
+//
+//    @Test
+//    void select1Calc2ColsFormula() {
+//        setup(3, 30, 12);
+//        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+//        runner.test("Select-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+//    }
+//
+//    @Test
+//    void select2Calcs2ColsFormula() {
+//        setup(2, 35, 17);
+//        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
+//        runner.test("Select-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
+//    }
+//
+//    @Test
+//    void update1Calc1ColsFormula() {
+//        setup(3, 55, 40);
+//        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+//        runner.test("Update-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+//    }
+//
+//    @Test
+//    void update1Calc2ColsFormula() {
+//        setup(3, 45, 30);
+//        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+//        runner.test("Update-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+//    }
 
     @Test
     void update2Calcs2ColsFormula() {
@@ -63,46 +63,46 @@ public class InlineFormulaTest {
         runner.test("Update-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
     }
 
-    @Test
-    void view1Calc1ColFormula() {
-        setup(3, 55, 50);
-        var q = "source.view(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-        runner.test("View-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-    }
-
-    @Test
-    void view1Calc2ColsFormula() {
-        setup(3, 40, 40);
-        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-        runner.test("View-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-    }
-
-    @Test
-    void view2Calcs2ColsFormula() {
-        setup(2, 35, 30);
-        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
-        runner.test("View-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
-    }
-
-    @Test
-    void updateView1Calc1ColFormula() {
-        setup(3, 60, 55);
-        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-        runner.test("UpdateView-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-    }
-
-    @Test
-    void updateView1Calc2ColsFormula() {
-        setup(3, 40, 38);
-        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-        runner.test("UpdateView-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-    }
-
-    @Test
-    void updateView2Calcs2ColsFormula() {
-        setup(2, 35, 35);
-        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
-        runner.test("UpdateView-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
-    }
+//    @Test
+//    void view1Calc1ColFormula() {
+//        setup(3, 55, 50);
+//        var q = "source.view(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+//        runner.test("View-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+//    }
+//
+//    @Test
+//    void view1Calc2ColsFormula() {
+//        setup(3, 40, 40);
+//        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+//        runner.test("View-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+//    }
+//
+//    @Test
+//    void view2Calcs2ColsFormula() {
+//        setup(2, 35, 30);
+//        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
+//        runner.test("View-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
+//    }
+//
+//    @Test
+//    void updateView1Calc1ColFormula() {
+//        setup(3, 60, 55);
+//        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+//        runner.test("UpdateView-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+//    }
+//
+//    @Test
+//    void updateView1Calc2ColsFormula() {
+//        setup(3, 40, 38);
+//        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+//        runner.test("UpdateView-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+//    }
+//
+//    @Test
+//    void updateView2Calcs2ColsFormula() {
+//        setup(2, 35, 35);
+//        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
+//        runner.test("UpdateView-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
+//    }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
@@ -21,40 +21,40 @@ public class InlineFormulaTest {
         runner.setScaleFactors(staticFactor, incFactor);
     }
 
-    @Test
-    void select1Calc1ColFormula() {
-        setup(6, 22, 9);
-        var q = "source.select(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-        runner.test("Select-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-    }
-
-    @Test
-    void select1Calc2ColsFormula() {
-        setup(6, 15, 8);
-        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-        runner.test("Select-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-    }
-
-    @Test
-    void select2Calcs2ColsFormula() {
-        setup(6, 13, 8);
-        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
-        runner.test("Select-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
-    }
-
-    @Test
-    void update1Calc1ColsFormula() {
-        setup(6, 30, 18);
-        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-        runner.test("Update-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-    }
-
-    @Test
-    void update1Calc2ColsFormula() {
-        setup(6, 22, 18);
-        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-        runner.test("Update-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-    }
+//    @Test
+//    void select1Calc1ColFormula() {
+//        setup(6, 22, 9);
+//        var q = "source.select(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+//        runner.test("Select-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+//    }
+//
+//    @Test
+//    void select1Calc2ColsFormula() {
+//        setup(6, 15, 8);
+//        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+//        runner.test("Select-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+//    }
+//
+//    @Test
+//    void select2Calcs2ColsFormula() {
+//        setup(6, 13, 8);
+//        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
+//        runner.test("Select-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
+//    }
+//
+//    @Test
+//    void update1Calc1ColsFormula() {
+//        setup(6, 30, 18);
+//        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+//        runner.test("Update-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+//    }
+//
+//    @Test
+//    void update1Calc2ColsFormula() {
+//        setup(6, 22, 18);
+//        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+//        runner.test("Update-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+//    }
 
     @Test
     void update2Calcs2ColsFormula() {
@@ -63,46 +63,46 @@ public class InlineFormulaTest {
         runner.test("Update-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
     }
 
-    @Test
-    void view1Calc1ColFormula() {
-        setup(6, 27, 25);
-        var q = "source.view(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-        runner.test("View-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-    }
-
-    @Test
-    void view1Calc2ColsFormula() {
-        setup(6, 22, 22);
-        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-        runner.test("View-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-    }
-
-    @Test
-    void view2Calcs2ColsFormula() {
-        setup(6, 17, 15);
-        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
-        runner.test("View-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
-    }
-
-    @Test
-    void updateView1Calc1ColFormula() {
-        setup(6, 35, 35);
-        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-        runner.test("UpdateView-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-    }
-
-    @Test
-    void updateView1Calc2ColsFormula() {
-        setup(6, 22, 20);
-        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-        runner.test("UpdateView-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-    }
-
-    @Test
-    void updateView2Calcs2ColsFormula() {
-        setup(6, 17, 17);
-        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
-        runner.test("UpdateView-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
-    }
+//    @Test
+//    void view1Calc1ColFormula() {
+//        setup(6, 27, 25);
+//        var q = "source.view(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+//        runner.test("View-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+//    }
+//
+//    @Test
+//    void view1Calc2ColsFormula() {
+//        setup(6, 22, 22);
+//        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+//        runner.test("View-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+//    }
+//
+//    @Test
+//    void view2Calcs2ColsFormula() {
+//        setup(6, 17, 15);
+//        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
+//        runner.test("View-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
+//    }
+//
+//    @Test
+//    void updateView1Calc1ColFormula() {
+//        setup(6, 35, 35);
+//        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+//        runner.test("UpdateView-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+//    }
+//
+//    @Test
+//    void updateView1Calc2ColsFormula() {
+//        setup(6, 22, 20);
+//        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+//        runner.test("UpdateView-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+//    }
+//
+//    @Test
+//    void updateView2Calcs2ColsFormula() {
+//        setup(6, 17, 17);
+//        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
+//        runner.test("UpdateView-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
+//    }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
@@ -21,88 +21,88 @@ public class InlineFormulaTest {
         runner.setScaleFactors(staticFactor, incFactor);
     }
 
-//    @Test
-//    void select1Calc1ColFormula() {
-//        setup(6, 22, 9);
-//        var q = "source.select(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-//        runner.test("Select-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-//    }
-//
-//    @Test
-//    void select1Calc2ColsFormula() {
-//        setup(6, 15, 8);
-//        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-//        runner.test("Select-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-//    }
-//
-//    @Test
-//    void select2Calcs2ColsFormula() {
-//        setup(6, 13, 8);
-//        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
-//        runner.test("Select-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
-//    }
-//
-//    @Test
-//    void update1Calc1ColsFormula() {
-//        setup(6, 30, 18);
-//        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-//        runner.test("Update-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-//    }
-//
-//    @Test
-//    void update1Calc2ColsFormula() {
-//        setup(6, 22, 18);
-//        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-//        runner.test("Update-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-//    }
+    @Test
+    void select1Calc1ColFormula() {
+        setup(6, 22, 9);
+        var q = "source.select(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+        runner.test("Select-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+    }
+
+    @Test
+    void select1Calc2ColsFormula() {
+        setup(6, 15, 8);
+        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+        runner.test("Select-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+    }
+
+    @Test
+    void select2Calcs2ColsFormula() {
+        setup(6, 13, 8);
+        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
+        runner.test("Select-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
+    }
+
+    @Test
+    void update1Calc1ColsFormula() {
+        setup(6, 30, 18);
+        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+        runner.test("Update-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+    }
+
+    @Test
+    void update1Calc2ColsFormula() {
+        setup(6, 22, 18);
+        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+        runner.test("Update-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+    }
 
     @Test
     void update2Calcs2ColsFormula() {
-        setup(6, 16, 12);
+        setup(4, 16, 0);
         var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
         runner.test("Update-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
     }
 
-//    @Test
-//    void view1Calc1ColFormula() {
-//        setup(6, 27, 25);
-//        var q = "source.view(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-//        runner.test("View-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-//    }
-//
-//    @Test
-//    void view1Calc2ColsFormula() {
-//        setup(6, 22, 22);
-//        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-//        runner.test("View-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-//    }
-//
-//    @Test
-//    void view2Calcs2ColsFormula() {
-//        setup(6, 17, 15);
-//        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
-//        runner.test("View-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
-//    }
-//
-//    @Test
-//    void updateView1Calc1ColFormula() {
-//        setup(6, 35, 35);
-//        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-//        runner.test("UpdateView-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-//    }
-//
-//    @Test
-//    void updateView1Calc2ColsFormula() {
-//        setup(6, 22, 20);
-//        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-//        runner.test("UpdateView-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-//    }
-//
-//    @Test
-//    void updateView2Calcs2ColsFormula() {
-//        setup(6, 17, 17);
-//        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
-//        runner.test("UpdateView-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
-//    }
+    @Test
+    void view1Calc1ColFormula() {
+        setup(6, 27, 25);
+        var q = "source.view(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+        runner.test("View-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+    }
+
+    @Test
+    void view1Calc2ColsFormula() {
+        setup(6, 22, 22);
+        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+        runner.test("View-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+    }
+
+    @Test
+    void view2Calcs2ColsFormula() {
+        setup(6, 17, 15);
+        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
+        runner.test("View-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
+    }
+
+    @Test
+    void updateView1Calc1ColFormula() {
+        setup(6, 35, 35);
+        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+        runner.test("UpdateView-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+    }
+
+    @Test
+    void updateView1Calc2ColsFormula() {
+        setup(6, 22, 20);
+        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+        runner.test("UpdateView-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+    }
+
+    @Test
+    void updateView2Calcs2ColsFormula() {
+        setup(6, 17, 17);
+        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
+        runner.test("UpdateView-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
+    }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
@@ -23,21 +23,21 @@ public class InlineFormulaTest {
 
     @Test
     void select1Calc1ColFormula() {
-        setup(6, 22, 9);
+        setup(6, 22, 8);
         var q = "source.select(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
         runner.test("Select-Sum- 1 Calc Using 1 Col", 1, q, "num2");
     }
 
     @Test
     void select1Calc2ColsFormula() {
-        setup(6, 14, 8);
+        setup(6, 14, 7);
         var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
         runner.test("Select-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
     }
 
     @Test
     void select2Calcs2ColsFormula() {
-        setup(6, 13, 8);
+        setup(6, 12, 6);
         var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
         runner.test("Select-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
     }
@@ -51,7 +51,7 @@ public class InlineFormulaTest {
 
     @Test
     void update1Calc2ColsFormula() {
-        setup(6, 22, 18);
+        setup(6, 22, 16);
         var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
         runner.test("Update-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
     }
@@ -65,14 +65,14 @@ public class InlineFormulaTest {
 
     @Test
     void view1Calc1ColFormula() {
-        setup(6, 32, 30);
+        setup(6, 32, 32);
         var q = "source.view(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
         runner.test("View-Sum- 1 Calc Using 1 Col", 1, q, "num2");
     }
 
     @Test
     void view1Calc2ColsFormula() {
-        setup(6, 22, 22);
+        setup(6, 23, 22);
         var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
         runner.test("View-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
     }
@@ -86,7 +86,7 @@ public class InlineFormulaTest {
 
     @Test
     void updateView1Calc1ColFormula() {
-        setup(6, 35, 35);
+        setup(6, 37, 35);
         var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
         runner.test("UpdateView-Sum- 1 Calc Using 1 Col", 1, q, "num2");
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
@@ -21,88 +21,88 @@ public class InlineFormulaTest {
         runner.setScaleFactors(staticFactor, incFactor);
     }
 
-//    @Test
-//    void select1Calc1ColFormula() {
-//        setup(3, 43, 18);
-//        var q = "source.select(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-//        runner.test("Select-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-//    }
-//
-//    @Test
-//    void select1Calc2ColsFormula() {
-//        setup(3, 30, 12);
-//        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-//        runner.test("Select-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-//    }
-//
-//    @Test
-//    void select2Calcs2ColsFormula() {
-//        setup(2, 35, 17);
-//        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
-//        runner.test("Select-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
-//    }
-//
-//    @Test
-//    void update1Calc1ColsFormula() {
-//        setup(3, 55, 40);
-//        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-//        runner.test("Update-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-//    }
-//
-//    @Test
-//    void update1Calc2ColsFormula() {
-//        setup(3, 45, 30);
-//        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-//        runner.test("Update-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-//    }
+    @Test
+    void select1Calc1ColFormula() {
+        setup(6, 22, 9);
+        var q = "source.select(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+        runner.test("Select-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+    }
+
+    @Test
+    void select1Calc2ColsFormula() {
+        setup(6, 15, 8);
+        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+        runner.test("Select-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+    }
+
+    @Test
+    void select2Calcs2ColsFormula() {
+        setup(6, 13, 8);
+        var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
+        runner.test("Select-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
+    }
+
+    @Test
+    void update1Calc1ColsFormula() {
+        setup(6, 30, 18);
+        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+        runner.test("Update-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+    }
+
+    @Test
+    void update1Calc2ColsFormula() {
+        setup(6, 22, 18);
+        var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+        runner.test("Update-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+    }
 
     @Test
     void update2Calcs2ColsFormula() {
-        setup(2, 32, 22);
+        setup(6, 16, 12);
         var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
         runner.test("Update-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
     }
 
-//    @Test
-//    void view1Calc1ColFormula() {
-//        setup(3, 55, 50);
-//        var q = "source.view(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-//        runner.test("View-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-//    }
-//
-//    @Test
-//    void view1Calc2ColsFormula() {
-//        setup(3, 40, 40);
-//        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-//        runner.test("View-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-//    }
-//
-//    @Test
-//    void view2Calcs2ColsFormula() {
-//        setup(2, 35, 30);
-//        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
-//        runner.test("View-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
-//    }
-//
-//    @Test
-//    void updateView1Calc1ColFormula() {
-//        setup(3, 60, 55);
-//        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
-//        runner.test("UpdateView-Sum- 1 Calc Using 1 Col", 1, q, "num2");
-//    }
-//
-//    @Test
-//    void updateView1Calc2ColsFormula() {
-//        setup(3, 40, 38);
-//        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
-//        runner.test("UpdateView-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
-//    }
-//
-//    @Test
-//    void updateView2Calcs2ColsFormula() {
-//        setup(2, 35, 35);
-//        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
-//        runner.test("UpdateView-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
-//    }
+    @Test
+    void view1Calc1ColFormula() {
+        setup(6, 27, 25);
+        var q = "source.view(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+        runner.test("View-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+    }
+
+    @Test
+    void view1Calc2ColsFormula() {
+        setup(6, 22, 22);
+        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+        runner.test("View-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+    }
+
+    @Test
+    void view2Calcs2ColsFormula() {
+        setup(6, 17, 15);
+        var q = "source.view(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
+        runner.test("View-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
+    }
+
+    @Test
+    void updateView1Calc1ColFormula() {
+        setup(6, 35, 35);
+        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
+        runner.test("UpdateView-Sum- 1 Calc Using 1 Col", 1, q, "num2");
+    }
+
+    @Test
+    void updateView1Calc2ColsFormula() {
+        setup(6, 22, 20);
+        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
+        runner.test("UpdateView-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
+    }
+
+    @Test
+    void updateView2Calcs2ColsFormula() {
+        setup(6, 17, 17);
+        var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
+        runner.test("UpdateView-Sum- 2 Calcs Using 2 Cols", 1, q, "num1", "num2");
+    }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
@@ -30,7 +30,7 @@ public class InlineFormulaTest {
 
     @Test
     void select1Calc2ColsFormula() {
-        setup(6, 15, 8);
+        setup(6, 14, 8);
         var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
         runner.test("Select-Sum- 1 Calc Using 2 Cols", 1, q, "num1", "num2");
     }
@@ -44,7 +44,7 @@ public class InlineFormulaTest {
 
     @Test
     void update1Calc1ColsFormula() {
-        setup(6, 30, 18);
+        setup(6, 32, 20);
         var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
         runner.test("Update-Sum- 1 Calc Using 1 Col", 1, q, "num2");
     }
@@ -65,7 +65,7 @@ public class InlineFormulaTest {
 
     @Test
     void view1Calc1ColFormula() {
-        setup(6, 27, 25);
+        setup(6, 32, 30);
         var q = "source.view(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
         runner.test("View-Sum- 1 Calc Using 1 Col", 1, q, "num2");
     }

--- a/src/main/java/io/deephaven/benchmark/api/BenchLog.java
+++ b/src/main/java/io/deephaven/benchmark/api/BenchLog.java
@@ -53,11 +53,14 @@ final public class BenchLog {
 
     /**
      * Set the name of the current test. This will be used at the beginning and end of the test's log info.
+     * <p/>
+     * Note: The symbol "#" is used is some components like <code>QueryLog</code> to treat with special behavior. In
+     * this log it is removed and treated like any other test heading.
      * 
      * @param name the name of the current log section (i.e. test name)
      */
     void setName(String name) {
-        this.name = name;
+        this.name = name.replaceAll("^[#]", "").trim();
     }
 
     private void write(String text) {

--- a/src/main/java/io/deephaven/benchmark/api/BenchTable.java
+++ b/src/main/java/io/deephaven/benchmark/api/BenchTable.java
@@ -160,8 +160,10 @@ final public class BenchTable implements Closeable {
     /**
      * Generate the table synchronously to a parquet file in the engine's data directory. If a parquet file already
      * exists in the Deephaven data directory that matches this table definition, use it and skip generation.
+     * 
+     * @return true if file was generated, otherwise false
      */
-    public void generateParquet() {
+    public boolean generateParquet() {
         columns.setDefaultDistribution(getDefaultDistro());
         String q = replaceTableAndGeneratorFields(useExistingParquetQuery);
 
@@ -172,7 +174,7 @@ final public class BenchTable implements Closeable {
 
         if (usedExistingParquet.get()) {
             Log.info("Table '%s' with %s rows already exists. Skipping", tableName, getRowCount());
-            return;
+            return false;
         }
         Log.info("Generating table '%s' with %s rows", tableName, getRowCount());
         long beginTime = System.currentTimeMillis();
@@ -188,6 +190,7 @@ final public class BenchTable implements Closeable {
         bench.query(q).execute();
 
         Log.info("DH Write Table Duration: " + (System.currentTimeMillis() - beginTime));
+        return true;
     }
 
     /**

--- a/src/main/java/io/deephaven/benchmark/api/QueryLog.java
+++ b/src/main/java/io/deephaven/benchmark/api/QueryLog.java
@@ -46,7 +46,9 @@ class QueryLog implements Closeable {
         if (!Files.exists(logFile)) {
             write("# Test Class - " + testClass.getName(), 2);
         }
-        write("## Test - " + name, 2);
+        var label = name.startsWith("#") ? "Setup" : "Test";
+        name = name.replaceAll("^[#]", "").trim();
+        write("## " + label + " - " + name, 2);
         for (int i = 0, n = queries.size(); i < n; i++) {
             write("### Query " + (i + 1), 1);
             write("````", 1);
@@ -57,7 +59,10 @@ class QueryLog implements Closeable {
 
     /**
      * Set the name of the current test. The query log records queries for a test class and denotes queries according to
-     * user-supplied test names
+     * user-supplied test names.
+     * <p/>
+     * Note: The special character "#" is used to denote that this name is not a test name. This log uses it to denote
+     * test setup, while other file handlers, like <code>BenchResult</code>, treat it as "skip recording results"
      * 
      * @param name the name of the current section (ex. test name)
      */


### PR DESCRIPTION
- Added support for restarting docker after parquet generation
  - Restart only if parquet is generated, not when reused
- Re-scaled all inline formula benchmarks to be more meaningful
- Updated Query Log to handle parquet generation query logging more clearly