### PR TITLE
Add extra check for existing parquet file

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -340,12 +340,7 @@ final public class StandardTestRunner {
     }
 
     void generateTable(String name, String distribution) {
-        var isNew = switch (name) {
-            case "source" -> generateSourceTable(distribution);
-            case "right" -> generateRightTable(distribution);
-            case "timed" -> generateTimedTable(distribution);
-            default -> throw new RuntimeException("Undefined table name: " + name);
-        };
+        var isNew = generateNamedTable(name, distribution);
         if (isNew) {
             if (!api.isClosed()) {
                 api.setName("# Data Table Generation " + name);
@@ -353,7 +348,18 @@ final public class StandardTestRunner {
                 api.close();
             }
             initialize(testInst);
+            // This should not necessary. Why does DH need it?
+            generateNamedTable(name, distribution);
         }
+    }
+
+    boolean generateNamedTable(String name, String distribution) {
+        return switch (name) {
+            case "source" -> generateSourceTable(distribution);
+            case "right" -> generateRightTable(distribution);
+            case "timed" -> generateTimedTable(distribution);
+            default -> throw new RuntimeException("Undefined table name: " + name);
+        };
     }
 
     boolean generateSourceTable(String distribution) {


### PR DESCRIPTION
For an unknown reason, adding an extra check after generating the parquet file fixes the issue with messed up timestamp updates.  From a coding perspective, the fix does nothing meaningful.

Steps for Using Time-based Parquet (Doesn't Work)
- Does an equivalent parquet file already exists?
- If no, generate parquet file, hard link _time.parquet_, and restart Docker
- If yes, hard link _time.parquet_
- Load parquet and update timestamp to be only ascending

Steps for Using Time-based Parquet (Works)
- Does an equivalent parquet file already exists?
- If no, generate parquet file, hard link _time.parquet_, restart Docker, **hard link _time.parquet_ again**
- If yes, hard link _time.parquet_
- Load parquet and update timestamp to be only ascending

The steps that work are the same as the steps that don't, except that we go through the motions of scanning the _data_ directory for the appropriate parquet file --which is there because we just made it-- and continuing on. That extra step should not be necessary, but without it the row ids somehow get messed up on the _timestamp_ update.

This is not a satisfying answer, but it works. 