### PR TITLE
Fix Standard Runner Restart Issue and VectorTest Recale

### DIFF
--- a/.github/scripts/build-server-distribution-remote.sh
+++ b/.github/scripts/build-server-distribution-remote.sh
@@ -34,7 +34,10 @@ echo "BRANCH: ${BRANCH_NAME}"
 title "-- Cloning deephaven-core --"
 cd ${GIT_DIR}
 rm -rf deephaven-core
-git clone -b ${BRANCH_NAME} --single-branch https://github.com/${OWNER}/deephaven-core.git
+# Do not use --single-branch here, because it does not allow checkout by commit hash 
+git clone https://github.com/${OWNER}/deephaven-core.git
+cd deephaven-core
+git checkout ${BRANCH_NAME}
 
 title "-- Cloning deephaven-server-docker --"
 cd ${GIT_DIR}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -27,7 +27,6 @@ final public class StandardTestRunner {
     private String mainTable = "source";
     private Bench api;
     private Controller controller;
-    private long scaleRowCount;
     private int staticFactor = 1;
     private int incFactor = 1;
     private int rowCountFactor = 1;
@@ -97,7 +96,6 @@ final public class StandardTestRunner {
      */
     public void setRowFactor(int rowCountFactor) {
         this.rowCountFactor = rowCountFactor;
-        this.scaleRowCount = (long) (api.propertyAsIntegral("scale.row.count", "100000") * rowCountFactor);
     }
 
     /**
@@ -161,6 +159,10 @@ final public class StandardTestRunner {
         }
     }
 
+    long getGeneratedRowCount() {
+        return (long) (api.propertyAsIntegral("scale.row.count", "100000") * rowCountFactor);
+    }
+
     long getMaxExpectedRowCount(long expectedRowCount, long scaleFactor) {
         return (expectedRowCount < 1) ? Long.MAX_VALUE : expectedRowCount;
     }
@@ -174,11 +176,11 @@ final public class StandardTestRunner {
                 'timestamp=timestamp.plusMillis((long)(ii / ${rows}) * ${rows})'
             ]).select()
             """;
-            return read.replace("${scaleFactor}", "" + scaleFactor).replace("${rows}", "" + scaleRowCount);
+            return read.replace("${scaleFactor}", "" + scaleFactor).replace("${rows}", "" + getGeneratedRowCount());
         }
 
         var read = "read('/data/${mainTable}.parquet').select(formulas=[${loadColumns}])";
-        read = (loadColumns.length == 0) ? ("empty_table(" + scaleRowCount + ")") : read;
+        read = (loadColumns.length == 0) ? ("empty_table(" + getGeneratedRowCount() + ")") : read;
 
         if (scaleFactor > 1) {
             read = "merge([${readTable}] * ${scaleFactor})".replace("${readTable}", read);
@@ -314,7 +316,6 @@ final public class StandardTestRunner {
         this.api = Bench.create(testInst);
         this.controller = new DeephavenDockerController(api.property("docker.compose.file", ""),
                 api.property("deephaven.addr", ""));
-        this.scaleRowCount = api.propertyAsIntegral("scale.row.count", "100000");
         restartDocker();
         api.query(query).execute();
     }
@@ -371,7 +372,7 @@ final public class StandardTestRunner {
                 .add("key3", "int", "[0-8]", distribution)
                 .add("key4", "int", "[0-98]", distribution)
                 .add("key5", "string", "[1-1000000]", distribution)
-                .withRowCount(scaleRowCount)
+                .withRowCount(getGeneratedRowCount())
                 .generateParquet();
     }
 
@@ -393,7 +394,7 @@ final public class StandardTestRunner {
 
     boolean generateTimedTable(String distribution) {
         long minTime = 1676557157537L;
-        long maxTime = minTime + scaleRowCount - 1;
+        long maxTime = minTime + getGeneratedRowCount() - 1;
         return api.table("timed")
                 .add("timestamp", "timestamp-millis", "[" + minTime + "-" + maxTime + "]", "ascending")
                 .add("num1", "double", "[0-4]", distribution)

--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -340,12 +340,7 @@ final public class StandardTestRunner {
     }
 
     void generateTable(String name, String distribution) {
-        var isNew = switch (name) {
-            case "source" -> generateSourceTable(distribution);
-            case "right" -> generateRightTable(distribution);
-            case "timed" -> generateTimedTable(distribution);
-            default -> throw new RuntimeException("Undefined table name: " + name);
-        };
+        var isNew = generateNamedTable(name, distribution);
         if (isNew) {
             if (!api.isClosed()) {
                 api.setName("# Data Table Generation " + name);
@@ -353,7 +348,18 @@ final public class StandardTestRunner {
                 api.close();
             }
             initialize(testInst);
+            // This should not necessary. Why does DH need it?
+            generateNamedTable(name, distribution);
         }
+    }
+
+    boolean generateNamedTable(String name, String distribution) {
+        return switch (name) {
+            case "source" -> generateSourceTable(distribution);
+            case "right" -> generateRightTable(distribution);
+            case "timed" -> generateTimedTable(distribution);
+            default -> throw new RuntimeException("Undefined table name: " + name);
+        };
     }
 
     boolean generateSourceTable(String distribution) {

--- a/src/it/java/io/deephaven/benchmark/tests/standard/vectors/VectorTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/vectors/VectorTest.java
@@ -14,20 +14,20 @@ public class VectorTest {
     void vectorAggDenseData() {
         runner.setRowFactor(6);
         runner.table("source", "linearConv");
-        runner.setScaleFactors(10, 0);  // 8
+        runner.setScaleFactors(10, 8);
         runner.addSetupQuery("source = source.group_by(['key5'])");
         var q = "source.update(['Calc=avg(num2)+max(num2)-min(num2)+std(num2)-median(num2)'])";
         runner.test("Vector- 5 Calcs 1M Groups Dense Data", q, "key5", "num2");
     }
 
-//    @Test
-//    void vectorAggSparseData() {
-//        runner.setRowFactor(6);
-//        runner.table("source", "ascending");
-//        runner.setScaleFactors(3, 2);
-//        runner.addSetupQuery("source = source.group_by(['key5'])");
-//        var q = "source.update(['Calc=avg(num2)+max(num2)-min(num2)+std(num2)-median(num2)'])";
-//        runner.test("Vector- 5 Calcs 1M Groups Sparse Data", q, "key5", "num2");
-//    }
+    @Test
+    void vectorAggSparseData() {
+        runner.setRowFactor(6);
+        runner.table("source", "ascending");
+        runner.setScaleFactors(3, 2);
+        runner.addSetupQuery("source = source.group_by(['key5'])");
+        var q = "source.update(['Calc=avg(num2)+max(num2)-min(num2)+std(num2)-median(num2)'])";
+        runner.test("Vector- 5 Calcs 1M Groups Sparse Data", q, "key5", "num2");
+    }
 
 }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/vectors/VectorTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/vectors/VectorTest.java
@@ -12,22 +12,22 @@ public class VectorTest {
 
     @Test
     void vectorAggDenseData() {
-        runner.setRowFactor(4);
+        runner.setRowFactor(6);
         runner.table("source", "linearConv");
-        runner.setScaleFactors(12, 12);
+        runner.setScaleFactors(10, 0);  // 8
         runner.addSetupQuery("source = source.group_by(['key5'])");
         var q = "source.update(['Calc=avg(num2)+max(num2)-min(num2)+std(num2)-median(num2)'])";
         runner.test("Vector- 5 Calcs 1M Groups Dense Data", q, "key5", "num2");
     }
-    
-    @Test
-    void vectorAggSparseData() {
-        runner.setRowFactor(4);
-        runner.table("source", "ascending");
-        runner.setScaleFactors(2, 2);
-        runner.addSetupQuery("source = source.group_by(['key5'])");
-        var q = "source.update(['Calc=avg(num2)+max(num2)-min(num2)+std(num2)-median(num2)'])";
-        runner.test("Vector- 5 Calcs 1M Groups Sparse Data", q, "key5", "num2");
-    }
+
+//    @Test
+//    void vectorAggSparseData() {
+//        runner.setRowFactor(6);
+//        runner.table("source", "ascending");
+//        runner.setScaleFactors(3, 2);
+//        runner.addSetupQuery("source = source.group_by(['key5'])");
+//        var q = "source.update(['Calc=avg(num2)+max(num2)-min(num2)+std(num2)-median(num2)'])";
+//        runner.test("Vector- 5 Calcs 1M Groups Sparse Data", q, "key5", "num2");
+//    }
 
 }

--- a/src/main/java/io/deephaven/benchmark/api/BenchTable.java
+++ b/src/main/java/io/deephaven/benchmark/api/BenchTable.java
@@ -173,7 +173,7 @@ final public class BenchTable implements Closeable {
         }).execute();
 
         if (usedExistingParquet.get()) {
-            Log.info("Table '%s' with %s rows already exists. Skipping", tableName, getRowCount());
+            Log.info("Using existing table '%s' with %s rows", tableName, getRowCount());
             return false;
         }
         Log.info("Generating table '%s' with %s rows", tableName, getRowCount());


### PR DESCRIPTION
- Fixed standard test runner issue where Docker restart after data generation was effectively generating again at a lower scale
  - This affected < 1% of benchmarks
- Re-scaled VectorTest, which was affected by this bug
- Added support for using deephaven-core commit hash for docker build source