### PR TITLE
Change Parquet "3 Long Cols" to "3 Integral Cols"

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/file/ParquetColTypeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/file/ParquetColTypeTest.java
@@ -14,14 +14,14 @@ class ParquetColTypeTest {
     @Order(1)
     void writeThreeIntegralCols() {
         runner.setScaleFactors(5, 15);
-        runner.runParquetWriteTest("ParquetWrite- 3 Long Cols -Static", "NONE", "short10K", "int10K", "long10K");
+        runner.runParquetWriteTest("ParquetWrite- 3 Integral Cols -Static", "NONE", "short10K", "int10K", "long10K");
     }
 
     @Test
     @Order(2)
     void readThreeIntegralCols() {
         runner.setScaleFactors(5, 15);
-        runner.runParquetReadTest("ParquetRead- 3 Long Cols -Static");
+        runner.runParquetReadTest("ParquetRead- 3 Integral Cols -Static");
     }
 
     @Test


### PR DESCRIPTION
Change two benchmark test names to better reflect the tests:
- `ParquetWrite- 3 Long Cols -Static` to `ParquetWrite- 3 Integral Cols -Static`
- `ParquetRead- 3 Long Cols -Static` to `ParquetRead- 3 Integral Cols -Static`


