### PR TITLE
Fix csv read benchmark data types

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/file/CsvColTypeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/file/CsvColTypeTest.java
@@ -12,16 +12,16 @@ class CsvColTypeTest {
 
     @Test
     @Order(1)
-    void writeThreeIntegralCols() {
-        runner.setScaleFactors(5, 3);
-        runner.runCsvWriteTest("CsvWrite- 3 Integral Cols -Static", "short10K", "int10K", "long10K");
+    void writeFourIntegralCols() {
+        runner.setScaleFactors(5, 2);
+        runner.runCsvWriteTest("CsvWrite- 4 Integral Cols -Static", "byte100", "short10K", "int10K", "long10K");
     }
 
     @Test
     @Order(2)
-    void readThreeIntegralCols() {
-        runner.setScaleFactors(5, 3);
-        runner.runCsvReadTest("CsvRead- 3 Integral Cols -Static", "short10K", "int10K", "long10K");
+    void readFourIntegralCols() {
+        runner.setScaleFactors(5, 2);
+        runner.runCsvReadTest("CsvRead- 4 Integral Cols -Static", "byte100", "short10K", "int10K", "long10K");
     }
 
     @Test

--- a/src/it/java/io/deephaven/benchmark/tests/standard/file/FileTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/file/FileTestRunner.java
@@ -194,6 +194,7 @@ class FileTestRunner {
             case "long10K" -> "(ii % 10000)";
             case "int10K" -> "((int)(ii % 10000))";
             case "short10K" -> "((short)(ii % 10000))";
+            case "byte100" -> "((byte)(ii % 100))";
             case "bigDec10K" -> "java.math.BigDecimal.valueOf(ii % 10000)";
             case "intArr5" -> array5;
             case "intVec5" -> "vec(" + array5 + ")";
@@ -214,8 +215,9 @@ class FileTestRunner {
         return switch (columnName) {
             case "str10K" -> "dht.string";
             case "long10K" -> "dht.long";
-            case "int10K" -> "dht.long";
+            case "int10K" -> "dht.int32";
             case "short10K" -> "dht.short";
+            case "byte100" -> "dht.byte";
             case "bigDec10K" -> "dht.BigDecimal";
             case "intArr5" -> "dht.int_array";
             case "intVec5" -> "dht.int_array";

--- a/src/it/java/io/deephaven/benchmark/tests/standard/file/FileTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/file/FileTestRunner.java
@@ -214,7 +214,7 @@ class FileTestRunner {
         return switch (columnName) {
             case "str10K" -> "dht.string";
             case "long10K" -> "dht.long";
-            case "int10K" -> "dht.int_";
+            case "int10K" -> "dht.int64";
             case "short10K" -> "dht.short";
             case "bigDec10K" -> "dht.BigDecimal";
             case "intArr5" -> "dht.int_array";

--- a/src/it/java/io/deephaven/benchmark/tests/standard/file/FileTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/file/FileTestRunner.java
@@ -214,7 +214,7 @@ class FileTestRunner {
         return switch (columnName) {
             case "str10K" -> "dht.string";
             case "long10K" -> "dht.long";
-            case "int10K" -> "dht.int64";
+            case "int10K" -> "dht.long";
             case "short10K" -> "dht.short";
             case "bigDec10K" -> "dht.BigDecimal";
             case "intArr5" -> "dht.int_array";

--- a/src/it/java/io/deephaven/benchmark/tests/standard/file/ParquetColTypeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/file/ParquetColTypeTest.java
@@ -12,16 +12,17 @@ class ParquetColTypeTest {
 
     @Test
     @Order(1)
-    void writeThreeIntegralCols() {
-        runner.setScaleFactors(5, 15);
-        runner.runParquetWriteTest("ParquetWrite- 3 Integral Cols -Static", "NONE", "short10K", "int10K", "long10K");
+    void writeFourIntegralCols() {
+        runner.setScaleFactors(5, 12);
+        runner.runParquetWriteTest("ParquetWrite- 4 Integral Cols -Static", "NONE", "byte100", "short10K", "int10K",
+                "long10K");
     }
 
     @Test
     @Order(2)
-    void readThreeIntegralCols() {
-        runner.setScaleFactors(5, 15);
-        runner.runParquetReadTest("ParquetRead- 3 Integral Cols -Static");
+    void readFourIntegralCols() {
+        runner.setScaleFactors(5, 12);
+        runner.runParquetReadTest("ParquetRead- 4 Integral Cols -Static");
     }
 
     @Test


### PR DESCRIPTION
- Related to PR https://github.com/deephaven/deephaven-core/pull/5602
- The above fix made it possible to both fix the breaking change and use data types correctly
- Previously, using int_ yielded a 64 bit int.  So, a test using short, int_, long was actually doing short, long, long
- Changed the CSV and Parquet Integral tests to use byte, short, int and long
- Verified those types do show up in Deephaven when read in