### PR TITLE
Design Changes for Dir Struct, Tagged Iterations, Metrics

### DIFF
--- a/.github/resources/nightly-scale-benchmark.properties
+++ b/.github/resources/nightly-scale-benchmark.properties
@@ -18,7 +18,7 @@ kafka.consumer.addr=redpanda:29092
 default.completion.timeout=10 minutes
 
 # Default data distribution for column data (random, ascending, descending, runlength)
-default.data.distribution=random
+default.data.distribution=${baseDistrib}
 
 # Slows down record generation (Used for experiments not full test runs)
 generator.pause.per.row=0 millis
@@ -27,7 +27,7 @@ generator.pause.per.row=0 millis
 record.compression=LZ4
 
 # Row count to scale tests (Tests can override but typically do not)
-scale.row.count=10000000
+scale.row.count=${baseRowCount}
 
 # True: Use a timestamp for the parent directory of each test run
 # False: Overwrite previous test results for each test run

--- a/.github/resources/release-scale-benchmark.properties
+++ b/.github/resources/release-scale-benchmark.properties
@@ -18,7 +18,7 @@ kafka.consumer.addr=redpanda:29092
 default.completion.timeout=10 minutes
 
 # Default data distribution for column data (random, ascending, descending, runlength)
-default.data.distribution=random
+default.data.distribution=${baseDistrib}
 
 # Slows down record generation (Used for experiments not full test runs)
 generator.pause.per.row=0 millis
@@ -27,7 +27,7 @@ generator.pause.per.row=0 millis
 record.compression=LZO
 
 # Row count to scale tests (Tests can override but typically do not)
-scale.row.count=10000000
+scale.row.count=${baseRowCount}
 
 # True: Use a timestamp for the parent directory of each test run
 # False: Overwrite previous test results for each test run

--- a/.github/scripts/base62.sh
+++ b/.github/scripts/base62.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 
-# Convert the given Base 10 number to Base 58 characters
+# Convert the given Base 10 number to Base 62 characters
 # ex. base62.sh 1718738365297350992 
 # ex. ./base62.sh $(date +%s%03N) 
 

--- a/.github/scripts/base62.sh
+++ b/.github/scripts/base62.sh
@@ -3,13 +3,13 @@
 set -o errexit
 set -o pipefail
 
-# Convert the given number to base62 characters
+# Convert the given Base 10 number to Base 58 characters
 # ex. base62.sh 1718738365297350992 
-# ex. base62.sh $(date +%s%N) 
+# ex. ./base62.sh $(date +%s%03N) 
 
 DECNUM=$1
+BASE62=($(echo {0..9} {A..Z} {a..z}))
 
-BASE62=($(echo {0..9} {a..z} {A..Z}))
 for i in $(bc <<< "obase=62; ${DECNUM}"); do
   echo -n ${BASE62[$(( 10#$i ))]}
 done && echo

--- a/.github/scripts/base62.sh
+++ b/.github/scripts/base62.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+# Convert the given number to base62 characters
+# ex. base62.sh 1718738365297350992 
+# ex. base62.sh $(date +%s%N) 
+
+DECNUM=$1
+
+BASE62=($(echo {0..9} {a..z} {A..Z}))
+for i in $(bc <<< "obase=62; ${DECNUM}"); do
+  echo -n ${BASE62[$(( 10#$i ))]}
+done && echo
+
+SCRIPT_DIR=$(temp=$(realpath "$0") && dirname "$temp")
+echo $SCRIPT_DIR

--- a/.github/scripts/base62.sh
+++ b/.github/scripts/base62.sh
@@ -14,5 +14,3 @@ for i in $(bc <<< "obase=62; ${DECNUM}"); do
   echo -n ${BASE62[$(( 10#$i ))]}
 done && echo
 
-SCRIPT_DIR=$(temp=$(realpath "$0") && dirname "$temp")
-echo $SCRIPT_DIR

--- a/.github/scripts/build-server-distribution-remote.sh
+++ b/.github/scripts/build-server-distribution-remote.sh
@@ -7,6 +7,11 @@ set -o pipefail
 # The supplied argument can be an image name or <owner>::<branch>
 # Ensure that the artifacts and Deephaven version are available in standard directories
 
+if [[ $# != 1 ]]; then
+  echo "$0: Missing docker image/branch argument"
+  exit 1
+fi
+
 HOST=`hostname`
 GIT_DIR=/root/git
 DEEPHAVEN_DIR=/root/deephaven
@@ -16,11 +21,6 @@ BUILD_JAVA=temurin-11-jdk-amd64
 
 if [ ! -d "${DEEPHAVEN_DIR}" ]; then
   echo "$0: Missing one or more Benchmark setup directories"
-  exit 1
-fi
-
-if [[ $# != 1 ]]; then
-  echo "$0: Missing docker image/branch argument"
   exit 1
 fi
 

--- a/.github/scripts/fetch-results-local.sh
+++ b/.github/scripts/fetch-results-local.sh
@@ -54,6 +54,7 @@ TMP_SVG_DIR=${DEST_DIR}/tmp-svg
 mkdir -p ${TMP_SVG_DIR}
 mv ${DEST_DIR}/*.svg ${TMP_SVG_DIR}
 mv ${TMP_SVG_DIR}/${RUN_TYPE}-benchmark-summary.svg ${DEST_DIR}/benchmark-summary.svg
+cp ${DEST_DIR}/benchmark-summary.svg ${DEST_DIR}/../
 rm -rf ${TMP_SVG_DIR}
 
 # Compress CSV and Test Logs

--- a/.github/scripts/fetch-results-local.sh
+++ b/.github/scripts/fetch-results-local.sh
@@ -17,7 +17,7 @@ USER=$2
 SCRIPT_DIR=$3
 RUN_TYPE=$4
 ACTOR=$5
-RUN_LABEL=${6:-$(echo -n "set-"; ${SCRIPT_DIR}/base62.sh $(date +%s%N))}
+RUN_LABEL=${6:-$(echo -n "set-"; ${SCRIPT_DIR}/base62.sh $(date +%s%03N))}
 RUN_DIR=/root/run
 
 # Pull results from the benchmark server

--- a/.github/scripts/fetch-results-local.sh
+++ b/.github/scripts/fetch-results-local.sh
@@ -17,7 +17,7 @@ USER=$2
 SCRIPT_DIR=$3
 RUN_TYPE=$4
 ACTOR=$5
-RUN_LABEL=${5:-$(${SCRIPT_DIR}/base62.sh $(date +%s%N))}
+RUN_LABEL=${6:-$(${SCRIPT_DIR}/base62.sh $(date +%s%N))}
 RUN_DIR=/root/run
 
 # Pull results from the benchmark server

--- a/.github/scripts/fetch-results-local.sh
+++ b/.github/scripts/fetch-results-local.sh
@@ -7,17 +7,18 @@ set -o nounset
 # Fetches Benchmark results and logs from the remote test server and
 # compresses the runs before upload
 
+if [[ $# != 6 ]]; then
+  echo "$0: Missing host, user, run type, script dir, actor, or run label arguments"
+  exit 1
+fi
+
 HOST=$1
 USER=$2
-RUN_TYPE=$3
-ACTOR=${4:-}
-RUN_LABEL=${5:-}
+SCRIPT_DIR=$3
+RUN_TYPE=$4
+ACTOR=$5
+RUN_LABEL=${5:-$(${SCRIPT_DIR}/base62.sh $(date +%s%N))}
 RUN_DIR=/root/run
-
-if [[ $# != 3 ]] && [[ $# != 5 ]]; then
-    echo "$0: Missing host, user, run type, actor, or run label arguments"
-    exit 1
-fi
 
 # Pull results from the benchmark server
 scp -r ${USER}@${HOST}:${RUN_DIR}/results .
@@ -25,15 +26,8 @@ scp -r ${USER}@${HOST}:${RUN_DIR}/logs .
 scp -r ${USER}@${HOST}:${RUN_DIR}/*.jar .
 
 # If the RUN_TYPE is adhoc, userfy the destination directory
-DEST_DIR=${RUN_TYPE}
-if [ "${RUN_TYPE}" = "adhoc" ]; then
-    if [ -z "${ACTOR}" ] || [ -z "${RUN_LABEL}" ]; then
-        echo "$0: Missing actor of run label argument for adhoc run type"
-        exit 1
-    fi
-    DEST_DIR=${RUN_TYPE}/${ACTOR}/${RUN_LABEL}
-    mkdir -p ${DEST_DIR}
-fi
+DEST_DIR=${RUN_TYPE}/${ACTOR}/${RUN_LABEL}
+mkdir -p ${DEST_DIR}
 
 rm -rf ${DEST_DIR}
 mv results/ ${DEST_DIR}/
@@ -51,8 +45,8 @@ rm -rf ${TMP_SVG_DIR}
 # Compress CSV and Test Logs
 for runId in `find ${DEST_DIR}/ -name "run-*"`
 do
-    (cd ${runId}; gzip *.csv)
-    (cd ${runId}/test-logs; tar -zcvf test-logs.tgz *; mv test-logs.tgz ../)
-    rm -rf ${runId}/test-logs/
+  (cd ${runId}; gzip *.csv)
+  (cd ${runId}/test-logs; tar -zcvf test-logs.tgz *; mv test-logs.tgz ../)
+  rm -rf ${runId}/test-logs/
 done
 

--- a/.github/scripts/fetch-results-local.sh
+++ b/.github/scripts/fetch-results-local.sh
@@ -20,6 +20,11 @@ ACTOR=$5
 RUN_LABEL=${6:-$(echo -n "set-"; ${SCRIPT_DIR}/base62.sh $(date +%s%03N))}
 RUN_DIR=/root/run
 
+# Get the date for the Set Label, since Github Workflows don't have 'with: ${{github.date}}'
+if [ "${RUN_LABEL}" = "<date>" ]; then
+  RUN_LABEL=$(date '+%Y-%m-%d')
+fi
+
 # Pull results from the benchmark server
 scp -r ${USER}@${HOST}:${RUN_DIR}/results .
 scp -r ${USER}@${HOST}:${RUN_DIR}/logs .

--- a/.github/scripts/fetch-results-local.sh
+++ b/.github/scripts/fetch-results-local.sh
@@ -25,10 +25,9 @@ scp -r ${USER}@${HOST}:${RUN_DIR}/results .
 scp -r ${USER}@${HOST}:${RUN_DIR}/logs .
 scp -r ${USER}@${HOST}:${RUN_DIR}/*.jar .
 
-# If the RUN_TYPE is adhoc, userfy the destination directory
+# Move the results into the destination directory
 DEST_DIR=${RUN_TYPE}/${ACTOR}/${RUN_LABEL}
 mkdir -p ${DEST_DIR}
-
 rm -rf ${DEST_DIR}
 mv results/ ${DEST_DIR}/
 

--- a/.github/scripts/fetch-results-local.sh
+++ b/.github/scripts/fetch-results-local.sh
@@ -7,8 +7,8 @@ set -o nounset
 # Fetches Benchmark results and logs from the remote test server and
 # compresses the runs before upload
 
-if [[ $# != 6 ]]; then
-  echo "$0: Missing host, user, run type, script dir, actor, or run label arguments"
+if [[ $# != 7 ]]; then
+  echo "$0: Missing host, user, run type, script dir, actor, docker img, or run label arguments"
   exit 1
 fi
 
@@ -18,11 +18,21 @@ SCRIPT_DIR=$3
 RUN_TYPE=$4
 ACTOR=$5
 RUN_LABEL=${6:-$(echo -n "set-"; ${SCRIPT_DIR}/base62.sh $(date +%s%03N))}
+DOCKER_IMG=$7
 RUN_DIR=/root/run
 
 # Get the date for the Set Label, since Github Workflows don't have 'with: ${{github.date}}'
 if [ "${RUN_LABEL}" = "<date>" ]; then
   RUN_LABEL=$(date '+%Y-%m-%d')
+fi
+
+# Get the version for the Set Label, since Github Workflows don't have 'with: ${{github.date}}'
+if [ "${RUN_LABEL}" = "<version>" ]; then
+  vers=${DOCKER_IMG}
+  major=$(printf '%02d\n' $(echo ${vers} | cut -d "." -f 1))
+  minor=$(printf '%03d\n' $(echo ${vers} | cut -d "." -f 2))
+  patch=$(printf '%02d\n' $(echo ${vers} | cut -d "." -f 3))
+  RUN_LABEL="${major}.${minor}.${patch}"
 fi
 
 # Pull results from the benchmark server

--- a/.github/scripts/fetch-results-local.sh
+++ b/.github/scripts/fetch-results-local.sh
@@ -17,7 +17,7 @@ USER=$2
 SCRIPT_DIR=$3
 RUN_TYPE=$4
 ACTOR=$5
-RUN_LABEL=${6:-$(${SCRIPT_DIR}/base62.sh $(date +%s%N))}
+RUN_LABEL=${6:-$(echo -n "set-"; ${SCRIPT_DIR}/base62.sh $(date +%s%N))}
 RUN_DIR=/root/run
 
 # Pull results from the benchmark server

--- a/.github/scripts/manage-deephaven-remote.sh
+++ b/.github/scripts/manage-deephaven-remote.sh
@@ -7,6 +7,11 @@ set -o pipefail
 # The directives argument can be start or stop
 # The supplied image argument can be an image name or <owner>::<branch>
 
+if [[ $# != 2 ]]; then
+  echo "$0: Missing docker directive or image/branch argument"
+  exit 1
+fi
+
 HOST=`hostname`
 DEEPHAVEN_DIR=/root/deephaven
 DIRECTIVE=$1
@@ -15,11 +20,6 @@ BRANCH_DELIM="::"
 
 if [ ! -d "${DEEPHAVEN_DIR}" ]; then
   echo "$0: Missing one or more Benchmark setup directories"
-  exit 1
-fi
-
-if [[ $# != 2 ]]; then
-  echo "$0: Missing docker directive or image/branch argument"
   exit 1
 fi
 

--- a/.github/scripts/run-benchmarks-remote.sh
+++ b/.github/scripts/run-benchmarks-remote.sh
@@ -19,7 +19,7 @@ ROW_COUNT=$4
 DISTRIB=$5
 ITERATIONS=$6
 TAG_ITERS=4
-HOST=`hostname`
+HOST=$(hostname)
 RUN_DIR=/root/run
 DEEPHAVEN_DIR=/root/deephaven
 

--- a/.github/scripts/run-benchmarks-remote.sh
+++ b/.github/scripts/run-benchmarks-remote.sh
@@ -48,7 +48,7 @@ for i in `seq 1 ${ITERATIONS}`; do
   java -Dbenchmark.profile=scale-benchmark.properties -jar deephaven-benchmark-*.jar -cp standard-tests.jar -p ${TEST_PACKAGE} -n "${TEST_PATTERN}"
 done
 
-if [ "${RUN_TYPE}" = "nightly" ] || [ "${RUN_TYPE}" = "release" ]; then
+if [ "${RUN_TYPE}" = "nightly" ] || [ "${RUN_TYPE}" = "adhoc" ]; then
   for i in `seq 1 ${TAG_ITERS}`; do
     java -Dbenchmark.profile=scale-benchmark.properties -jar deephaven-benchmark-*.jar -cp standard-tests.jar -p ${TEST_PACKAGE} -t "Iterate"
   done

--- a/.github/scripts/run-benchmarks-remote.sh
+++ b/.github/scripts/run-benchmarks-remote.sh
@@ -18,6 +18,7 @@ TEST_PATTERN="$3"
 ROW_COUNT=$4
 DISTRIB=$5
 ITERATIONS=$6
+TAG_ITERS=4
 HOST=`hostname`
 RUN_DIR=/root/run
 DEEPHAVEN_DIR=/root/deephaven
@@ -43,10 +44,15 @@ title "-- Running Benchmarks --"
 cd ${RUN_DIR}
 cat ${RUN_TYPE}-scale-benchmark.properties | sed 's|${baseRowCount}|'"${ROW_COUNT}|g" | sed 's|${baseDistrib}|'"${DISTRIB}|g" > scale-benchmark.properties
 
-for i in `seq 1 ${ITERATIONS}`
-do
+for i in `seq 1 ${ITERATIONS}`; do
   java -Dbenchmark.profile=scale-benchmark.properties -jar deephaven-benchmark-*.jar -cp standard-tests.jar -p ${TEST_PACKAGE} -n "${TEST_PATTERN}"
 done
+
+if [ "${RUN_TYPE}" = "nightly" ] || [ "${RUN_TYPE}" = "release" ]; then
+  for i in `seq 1 ${TAG_ITERS}`; do
+    java -Dbenchmark.profile=scale-benchmark.properties -jar deephaven-benchmark-*.jar -cp standard-tests.jar -p ${TEST_PACKAGE} -t "Iterate"
+  done
+fi
 
 title "-- Getting Docker Logs --"
 mkdir -p ${RUN_DIR}/logs

--- a/.github/scripts/run-benchmarks-remote.sh
+++ b/.github/scripts/run-benchmarks-remote.sh
@@ -48,7 +48,7 @@ for i in `seq 1 ${ITERATIONS}`; do
   java -Dbenchmark.profile=scale-benchmark.properties -jar deephaven-benchmark-*.jar -cp standard-tests.jar -p ${TEST_PACKAGE} -n "${TEST_PATTERN}"
 done
 
-if [ "${RUN_TYPE}" = "nightly" ] || [ "${RUN_TYPE}" = "adhoc" ]; then
+if [ "${RUN_TYPE}" = "nightly" ] || [ "${RUN_TYPE}" = "release" ]; then
   for i in `seq 1 ${TAG_ITERS}`; do
     java -Dbenchmark.profile=scale-benchmark.properties -jar deephaven-benchmark-*.jar -cp standard-tests.jar -p ${TEST_PACKAGE} -t "Iterate"
   done

--- a/.github/scripts/run-publish-local.sh
+++ b/.github/scripts/run-publish-local.sh
@@ -6,6 +6,7 @@ set -o nounset
 
 # Run queries that publish a secret slack channel. Queries operation exclusively
 # the deephaven-benchmark GCloud bucket
+
 if [[ $# != 3 ]]; then
   echo "$0: Missing run type or slack-channel or slack-uri arguments"
   exit 1

--- a/.github/scripts/run-ssh-local.sh
+++ b/.github/scripts/run-ssh-local.sh
@@ -8,15 +8,15 @@ set -o nounset
 # local working directory. Also, this script wraps arguments provided for the
 # remote scripts in single-quotes to avoid syntax errors.
 
-HOST=$1
-USER=$2
-SCRIPT_DIR=$3
-SCRIPT_NAME=$4
-
 if [[ $# -lt 4 ]]; then
 	echo "$0: Missing host, user, script dir, or script name argument"
 	exit 1
 fi
+
+HOST=$1
+USER=$2
+SCRIPT_DIR=$3
+SCRIPT_NAME=$4
 
 args=()
 for i in ${@:5}; do

--- a/.github/workflows/adhoc-remote-benchmarks.yml
+++ b/.github/workflows/adhoc-remote-benchmarks.yml
@@ -17,8 +17,9 @@ on:
        type: string
      run_label:
        description: 'Run Label'
-       required: true
+       required: false
        type: string
+       default: ''
      test_package:
        description: 'Benchmark Test Package'
        required: true

--- a/.github/workflows/adhoc-remote-benchmarks.yml
+++ b/.github/workflows/adhoc-remote-benchmarks.yml
@@ -17,8 +17,7 @@ on:
        type: string
      run_label:
        description: 'Run Label'
-       required: false
-       default: ''
+       required: true
        type: string
      test_package:
        description: 'Benchmark Test Package'

--- a/.github/workflows/adhoc-remote-benchmarks.yml
+++ b/.github/workflows/adhoc-remote-benchmarks.yml
@@ -17,9 +17,9 @@ on:
        type: string
      run_label:
        description: 'Run Label'
-       required: false
+       required: true
        type: string
-       default: ''
+       default: v${{ inputs.docker_image }}
      test_package:
        description: 'Benchmark Test Package'
        required: true

--- a/.github/workflows/adhoc-remote-benchmarks.yml
+++ b/.github/workflows/adhoc-remote-benchmarks.yml
@@ -17,7 +17,8 @@ on:
        type: string
      run_label:
        description: 'Run Label'
-       required: true
+       required: false
+       default: ''
        type: string
      test_package:
        description: 'Benchmark Test Package'

--- a/.github/workflows/adhoc-remote-benchmarks.yml
+++ b/.github/workflows/adhoc-remote-benchmarks.yml
@@ -16,10 +16,10 @@ on:
        default: 'edge'
        type: string
      run_label:
-       description: 'Run Label'
+       description: 'Set Label'
        required: true
        type: string
-       default: v${{ inputs.docker_image }}
+       default: ''
      test_package:
        description: 'Benchmark Test Package'
        required: true

--- a/.github/workflows/compare-remote-benchmarks.yml
+++ b/.github/workflows/compare-remote-benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       run_type: compare
       docker_image: ${{ inputs.docker_image }}
-      run_label: ""
+      run_label: "<version>"
       test_package: "io.deephaven.benchmark.tests.compare"
       test_class_regex: "^(Test.*|.+[.$]Test.*|.*Tests?)$"
       test_iterations: 1

--- a/.github/workflows/nightly-remote-benchmarks.yml
+++ b/.github/workflows/nightly-remote-benchmarks.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       run_type: nightly
       docker_image: edge
-      run_label: ""
+      run_label: "<date>"
       test_package: "io.deephaven.benchmark.tests.standard"
       test_class_regex: "^(Test.*|.+[.$]Test.*|.*Tests?)$"
       test_iterations: 1

--- a/.github/workflows/release-remote-benchmarks.yml
+++ b/.github/workflows/release-remote-benchmarks.yml
@@ -19,10 +19,10 @@ jobs:
     with:
       run_type: release
       docker_image: ${{ inputs.docker_image }}
-      run_label: "<date>"
+      run_label: v${{ inputs.docker_image }}
       test_package: "io.deephaven.benchmark.tests.standard"
-      test_class_regex: "^.*[.].*Parquet.*Col.*Test.*$"
+      test_class_regex: "^(Test.*|.+[.$]Test.*|.*Tests?)$"
       test_iterations: 1
-      scale_row_count: 100000
+      scale_row_count: 10000000
       distribution: random
     secrets: inherit

--- a/.github/workflows/release-remote-benchmarks.yml
+++ b/.github/workflows/release-remote-benchmarks.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       run_type: release
       docker_image: ${{ inputs.docker_image }}
-      run_label: ""
+      run_label: v${{ inputs.docker_image }}
       test_package: "io.deephaven.benchmark.tests.standard"
       test_class_regex: "^(Test.*|.+[.$]Test.*|.*Tests?)$"
       test_iterations: 1

--- a/.github/workflows/release-remote-benchmarks.yml
+++ b/.github/workflows/release-remote-benchmarks.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       run_type: release
       docker_image: ${{ inputs.docker_image }}
-      run_label: v${{ inputs.docker_image }}
+      run_label: "<version>"
       test_package: "io.deephaven.benchmark.tests.standard"
       test_class_regex: "^(Test.*|.+[.$]Test.*|.*Tests?)$"
       test_iterations: 1

--- a/.github/workflows/release-remote-benchmarks.yml
+++ b/.github/workflows/release-remote-benchmarks.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       run_type: release
       docker_image: ${{ inputs.docker_image }}
-      run_label: v${{ inputs.docker_image }}
+      run_label: "<date>"
       test_package: "io.deephaven.benchmark.tests.standard"
       test_class_regex: "^.*[.].*Parquet.*Col.*Test.*$"
       test_iterations: 1

--- a/.github/workflows/release-remote-benchmarks.yml
+++ b/.github/workflows/release-remote-benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
       docker_image: ${{ inputs.docker_image }}
       run_label: v${{ inputs.docker_image }}
       test_package: "io.deephaven.benchmark.tests.standard"
-      test_class_regex: "^(Test.*|.+[.$]Test.*|.*Tests?)$"
+      test_class_regex: "^.*[.].*Parquet.*Col.*Test.*$"
       test_iterations: 1
       scale_row_count: 100000
       distribution: random

--- a/.github/workflows/release-remote-benchmarks.yml
+++ b/.github/workflows/release-remote-benchmarks.yml
@@ -10,7 +10,7 @@ on:
      docker_image:
        description: 'Docker Image Name'
        required: true
-       default: '0.32.0'
+       default: '0.35.0'
        type: string
 
 jobs:
@@ -23,6 +23,6 @@ jobs:
       test_package: "io.deephaven.benchmark.tests.standard"
       test_class_regex: "^(Test.*|.+[.$]Test.*|.*Tests?)$"
       test_iterations: 1
-      scale_row_count: 10000000
+      scale_row_count: 100000
       distribution: random
     secrets: inherit

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -104,13 +104,6 @@ jobs:
         
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
-      
-    - name: Backup Existing Benchmark Summary SVG
-      run: |
-        SUMMARY_PREFIX=gs://deephaven-benchmark/${RUN_TYPE}/benchmark-summary
-        if gsutil stat ${SUMMARY_PREFIX}.svg &>/dev/null; then
-          gsutil mv ${SUMMARY_PREFIX}.svg ${SUMMARY_PREFIX}.prev.svg &>/dev/null
-        fi
 
     - name: Upload Benchmark Results to GCloud
       uses: google-github-actions/upload-cloud-storage@v1

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -95,7 +95,7 @@ jobs:
         
     - name: Fetch Benchmark Results and Prepare for Upload
       run: |
-        ${SD}/fetch-results-local.sh ${HOST} ${USER} ${RUN_TYPE} "${ACTOR}" "${RUN_LABEL}"
+        ${SD}/fetch-results-local.sh ${HOST} ${USER} ${SD} ${RUN_TYPE} "${ACTOR}" "${RUN_LABEL}"
 
     - name: Authorize GCloud Credentials
       uses: google-github-actions/auth@v1

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -95,7 +95,7 @@ jobs:
         
     - name: Fetch Benchmark Results and Prepare for Upload
       run: |
-        ${SD}/fetch-results-local.sh ${HOST} ${USER} ${SD} ${RUN_TYPE} "${ACTOR}" "${RUN_LABEL}"
+        ${SD}/fetch-results-local.sh ${HOST} ${USER} ${SD} ${RUN_TYPE} "${ACTOR}" "${RUN_LABEL}" "${DOCKER_IMG}"
 
     - name: Authorize GCloud Credentials
       uses: google-github-actions/auth@v1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Deephaven Benchmark
 
 [Summary of Latest Successful Nightly Benchmarks](docs/NightlySummary.md)
-![Operation Rate Change Tracking By Release](https://storage.googleapis.com/deephaven-benchmark/nightly/benchmark-summary.svg?)
+![Operation Rate Change Tracking By Release](https://storage.googleapis.com/deephaven-benchmark/nightly/deephaven/benchmark-summary.svg?)
 ([See Other Deephaven Summaries Below](#other-deephaven-summaries))
 
 The Benchmark framework provides support for gathering performance measurements and statistics for operations on tabular data.  It uses the JUnit
@@ -75,4 +75,4 @@ used for nightly Deephaven benchmarks. Either way the submission of the result t
 ## Other Deephaven Summaries
 
 [Summary of Comparison Benchmarks](docs/ComparisonSummary.md)
-![Operation Rate Product Comparison](https://storage.googleapis.com/deephaven-benchmark/compare/benchmark-summary.svg?)
+![Operation Rate Product Comparison](https://storage.googleapis.com/deephaven-benchmark/compare/deephaven/benchmark-summary.svg?)

--- a/docs/ComparisonSummary.md
+++ b/docs/ComparisonSummary.md
@@ -1,6 +1,6 @@
 # Comparison Benchmark Summary
 
-![Operation Rate Comparison](https://storage.googleapis.com/deephaven-benchmark/compare/benchmark-summary.svg?)
+![Operation Rate Comparison](https://storage.googleapis.com/deephaven-benchmark/compare/deephaven/benchmark-summary.svg?)
 
 ## Comparison Table Organization
 

--- a/docs/NightlySummary.md
+++ b/docs/NightlySummary.md
@@ -1,6 +1,6 @@
 # Nightly Benchmark Summary
 
-![Operation Rate Change Tracking By Release](https://storage.googleapis.com/deephaven-benchmark/nightly/benchmark-summary.svg?)
+![Operation Rate Change Tracking By Release](https://storage.googleapis.com/deephaven-benchmark/nightly/deephaven/benchmark-summary.svg?)
 
 ## Summary Table Organization
 

--- a/src/it/java/io/deephaven/benchmark/tests/experimental/mergescale/ScaleTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/experimental/mergescale/ScaleTestRunner.java
@@ -36,6 +36,8 @@ class ScaleTestRunner {
         from deephaven import new_table, merge, garbage_collect, agg
         from deephaven.column import int_col, float_col
         from deephaven.parquet import read
+        
+        bench_api_metrics_init()
 
         ${table} = ${readTable}
         garbage_collect()
@@ -45,11 +47,9 @@ class ScaleTestRunner {
            agg.pct(0.90, ['Percentile3=int1M'])
         ]
         
-        bench_api_metrics_snapshot()
         begin_time = time.perf_counter_ns()
         result = ${table}.agg_by(aggs, by=['str250', 'str640'])
         end_time = time.perf_counter_ns()
-        bench_api_metrics_snapshot()
         standard_metrics = bench_api_metrics_collect()
         
         stats = new_table([
@@ -85,7 +85,7 @@ class ScaleTestRunner {
         var controller = new DeephavenDockerController(api.property("docker.compose.file", ""), api.property("deephaven.addr", ""));
         if (!controller.restartService())
             return;
-        var metrics = new Metrics(Timer.now(), "test-runner", "setup", "docker");
+        var metrics = new Metrics(Timer.now(), "test-runner", "setup.docker");
         metrics.set("restart", timer.duration().toMillis(), "standard");
         api.metrics().add(metrics);
     }

--- a/src/it/java/io/deephaven/benchmark/tests/internal/metrics/MetricsCollectionTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/metrics/MetricsCollectionTest.java
@@ -47,6 +47,9 @@ public class MetricsCollectionTest {
 
     @Test
     public void collectMetricsToFile() throws Exception {
+        Path metricsFile = Bench.outputDir.resolve(Bench.metricsFileName);
+        Filer.delete(metricsFile);
+        
         var query = """
         bench_api_metrics_init()
         bench_api_metrics_add('c1','n1',2.0,'test')
@@ -61,7 +64,6 @@ public class MetricsCollectionTest {
         }).execute();
         api.close();
 
-        Path metricsFile = Bench.outputDir.resolve(Bench.metricsFileName);
         assertTrue(Files.exists(metricsFile), "Missing metrics output file");
         var text = Filer.getFileText(metricsFile);
         assertEquals("""

--- a/src/it/java/io/deephaven/benchmark/tests/internal/metrics/MetricsCollectionTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/internal/metrics/MetricsCollectionTest.java
@@ -6,77 +6,69 @@ import java.nio.file.Path;
 import java.util.*;
 import org.junit.jupiter.api.*;
 import io.deephaven.benchmark.api.Bench;
+import io.deephaven.benchmark.util.Filer;
 
 /**
- * Test to see what metrics are available in the remote Deephaven Server. Note. These tests should pass when DH is
- * JVM 17+
+ * Test to see what metrics are available in the remote Deephaven Server. Note. These tests should pass when DH is JVM
+ * 17+
  */
 public class MetricsCollectionTest {
     final Bench api = Bench.create(this);
 
     @Test
-    public void collect1MetricSet() {
+    public void collectMetricSet() {
         var query = """
-        from time import sleep
-        
-        bench_api_metrics_snapshot()
-        sleep(0.5)
+        bench_api_metrics_init()
+        bench_api_metrics_add('c1','n1',2.0,'test')
+        bench_api_metrics_add('c2','n2',2.0,'test')
         mymetrics = bench_api_metrics_collect()
         """;
 
         api.query(query).fetchAfter("mymetrics", table -> {
-            assertEquals("timestamp, origin, category, type, name, value, note", formatCols(table.getColumnNames()),
+            assertEquals("timestamp, origin, category, name, value, note", formatCols(table.getColumnNames()),
                     "Wrong column names");
-            int rowCount = table.getRowCount();
-            assertTrue(rowCount > 20, "Wrong row count. Got " + rowCount);
-            assertEquals("ClassLoadingImpl", table.getValue(0, "category"), "Wrong bean name");
-            assertEquals("TotalLoadedClassCount", table.getValue(0, "name"), "Wrong ");
-            assertTrue(table.getValue(3, "value").toString()
-                    .matches("init = .* used = .* committed = .* max = .*"));
+            assertEquals(2, table.getRowCount(), "Wrong row count");
         }).execute();
     }
 
     @Test
-    public void collect2MetricSets() {
+    public void collectNoMetrics() {
         var query = """
-        from time import sleep
-        
-        bench_api_metrics_snapshot()
-        sleep(0.5)
-        bench_api_metrics_snapshot()
+        bench_api_metrics_init()
         mymetrics = bench_api_metrics_collect()
         """;
 
         api.query(query).fetchAfter("mymetrics", table -> {
-            assertEquals("timestamp, origin, category, type, name, value, note", formatCols(table.getColumnNames()),
+            assertEquals("timestamp, origin, category, name, value, note", formatCols(table.getColumnNames()),
                     "Wrong column names");
-            int rowCount = table.getRowCount();
-            assertTrue(rowCount > 40, "Wrong row count. Got " + rowCount);
+            assertEquals(0, table.getRowCount(), "Wrong row count");
         }).execute();
     }
 
     @Test
     public void collectMetricsToFile() throws Exception {
         var query = """
-        from time import sleep
-        
-        bench_api_metrics_snapshot()
-        sleep(0.5)
+        bench_api_metrics_init()
+        bench_api_metrics_add('c1','n1',2.0,'test')
+        bench_api_metrics_add('c2','n2',2.0,'test')
         mymetrics = bench_api_metrics_collect()
         """;
 
         api.query(query).fetchAfter("mymetrics", table -> {
             int rowCount = table.getRowCount();
-            assertTrue(rowCount > 20, "Wrong row count. Got " + rowCount);
+            assertEquals(2, rowCount, "Wrong row count");
             api.metrics().add(table);
         }).execute();
         api.close();
 
         Path metricsFile = Bench.outputDir.resolve(Bench.metricsFileName);
         assertTrue(Files.exists(metricsFile), "Missing metrics output file");
-        var lines = Files.lines(metricsFile).toList();
-        assertEquals("benchmark_name,origin,timestamp,category,type,name,value,note", lines.get(0), "Wrong csv header");
-        assertTrue(lines.size() > 1, "CSV has no data");
+        var text = Filer.getFileText(metricsFile);
+        assertEquals("""
+        benchmark_name,origin,timestamp,name,value,note
+        MetricsCollectionTest,deephaven-engine,1720569321551,c1.n1,2.0,test
+        MetricsCollectionTest,deephaven-engine,1720569321551,c2.n2,2.0,test
+        """.trim().replaceAll("[\r\n]+", "\n"), text.replaceAll(",[0-9]+,", ",1720569321551,"), "Wrong csv data");
     }
 
     @AfterEach

--- a/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
@@ -57,6 +57,7 @@ public class InlineFormulaTest {
     }
 
     @Test
+    @Tag("Iterate")
     void update2Calcs2ColsFormula() {
         setup(6, 16, 10);
         var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc2cols2);

--- a/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaTestRunner.java
@@ -52,7 +52,7 @@ class KafkaTestRunner {
         dockerComposeFile = makeHeapAdjustedDockerCompose(dockerComposeFile, deephavenHeapGigs);
         var timer = api.timer();
         controller.restartService();
-        var metrics = new Metrics(Timer.now(), "test-runner", "setup", "docker");
+        var metrics = new Metrics(Timer.now(), "test-runner", "setup.docker");
         metrics.set("restart", timer.duration().toMillis(), "standard");
         api.metrics().add(metrics);
     }
@@ -103,9 +103,9 @@ class KafkaTestRunner {
         from deephaven.stream.kafka.consumer import TableType, KeyValueSpec
         import deephaven.dtypes as dht
         
+        bench_api_metrics_init()
         kc_spec = ${kafkaConsumerSpec}
         
-        bench_api_metrics_snapshot()
         begin_time = time.perf_counter_ns()
         
         consumer_tbl = kc.consume({ 'bootstrap.servers' : '${kafka.consumer.addr}' ${schemaRegistryURL} },
@@ -119,7 +119,6 @@ class KafkaTestRunner {
         ${awaitTableLoad}
         
         end_time = time.perf_counter_ns()
-        bench_api_metrics_snapshot()
         standard_metrics = bench_api_metrics_collect()
         
         stats = new_table([
@@ -202,7 +201,7 @@ class KafkaTestRunner {
         if (logText.isBlank())
             return;
         api.log().add("deephaven-engine", logText);
-        var metrics = new Metrics(Timer.now(), "test-runner", "teardown", "docker");
+        var metrics = new Metrics(Timer.now(), "test-runner", "teardown.docker");
         metrics.set("log", timer.duration().toMillis(), "standard");
         api.metrics().add(metrics);
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereInTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereInTest.java
@@ -28,6 +28,7 @@ public class WhereInTest {
     }
 
     @Test
+    @Tag("Iterate")
     void whereIn1Filter() {
         runner.setScaleFactors(135, 100);
         var q = "source.where_in(where_filter, cols=['key1 = set1'])";
@@ -35,6 +36,7 @@ public class WhereInTest {
     }
 
     @Test
+    @Tag("Iterate")
     void whereIn2Filter() {
         runner.setScaleFactors(67, 65);
         var q = "source.where_in(where_filter, cols=['key1 = set1', 'key2 = set2'])";

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereInTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereInTest.java
@@ -36,7 +36,6 @@ public class WhereInTest {
     }
 
     @Test
-    @Tag("Iterate")
     void whereIn2Filter() {
         runner.setScaleFactors(67, 65);
         var q = "source.where_in(where_filter, cols=['key1 = set1', 'key2 = set2'])";

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereNotInTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereNotInTest.java
@@ -6,8 +6,7 @@ import io.deephaven.benchmark.tests.standard.StandardTestRunner;
 
 /**
  * Standard tests for the whereNotIn table operation. Filters rows of data from the source table where the rows match
- * column values in the filter table.
- * Note: These benchmarks do the converse of the ones in WhereInTest
+ * column values in the filter table. Note: These benchmarks do the converse of the ones in WhereInTest
  */
 public class WhereNotInTest {
     final StandardTestRunner runner = new StandardTestRunner(this);
@@ -29,6 +28,7 @@ public class WhereNotInTest {
     }
 
     @Test
+    @Tag("Iterate")
     void whereNotIn1Filter() {
         runner.setScaleFactors(80, 75);
         var q = "source.where_not_in(where_filter, cols=['key1 = set1'])";
@@ -36,12 +36,13 @@ public class WhereNotInTest {
     }
 
     @Test
+    @Tag("Iterate")
     void whereNotIn2Filter() {
         runner.setScaleFactors(75, 65);
         var q = "source.where_not_in(where_filter, cols=['key1 = set1', 'key2 = set2'])";
         runner.test("WhereNotIn- 2 Filter Cols", q, "key1", "key2", "num1");
     }
-    
+
     @Test
     void whereNotIn3Filter() {
         runner.setScaleFactors(55, 50);

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereNotInTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereNotInTest.java
@@ -36,7 +36,6 @@ public class WhereNotInTest {
     }
 
     @Test
-    @Tag("Iterate")
     void whereNotIn2Filter() {
         runner.setScaleFactors(75, 65);
         var q = "source.where_not_in(where_filter, cols=['key1 = set1', 'key2 = set2'])";

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereOneOfTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereOneOfTest.java
@@ -18,6 +18,7 @@ public class WhereOneOfTest {
     }
 
     @Test
+    @Tag("Iterate")
     void whereOneOf1Filter() {
         runner.setScaleFactors(365, 300);
         var q = """

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereTest.java
@@ -7,7 +7,6 @@ import io.deephaven.benchmark.tests.standard.StandardTestRunner;
 /**
  * Standard tests for the where table operation. Filters rows of data from the source table.
  */
-@Tag("Iterate")
 public class WhereTest {
     final StandardTestRunner runner = new StandardTestRunner(this);
 
@@ -18,6 +17,7 @@ public class WhereTest {
     }
 
     @Test
+    @Tag("Iterate")
     void where1Filter() {
         runner.setScaleFactors(330, 310);
         var q = """

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereTest.java
@@ -7,6 +7,7 @@ import io.deephaven.benchmark.tests.standard.StandardTestRunner;
 /**
  * Standard tests for the where table operation. Filters rows of data from the source table.
  */
+@Tag("Iterate")
 public class WhereTest {
     final StandardTestRunner runner = new StandardTestRunner(this);
 

--- a/src/main/java/io/deephaven/benchmark/api/BenchMetrics.java
+++ b/src/main/java/io/deephaven/benchmark/api/BenchMetrics.java
@@ -16,7 +16,7 @@ import io.deephaven.benchmark.util.Numbers;
  */
 final public class BenchMetrics {
     static final String[] header =
-            {"benchmark_name", "origin", "timestamp", "category", "type", "name", "value", "note"};
+            {"benchmark_name", "origin", "timestamp", "name", "value", "note"};
     final List<Metrics> metrics = new ArrayList<>();
     final Path file;
     private String name = null;
@@ -42,11 +42,10 @@ final public class BenchMetrics {
             var origin = table.getValue(r, "origin").toString();
             var timestamp = table.getNumber(r, "timestamp").longValue();
             var category = table.getValue(r, "category").toString();
-            var type = formatType(table.getValue(r, "type").toString());
             var mname = table.getValue(r, "name").toString();
             var note = table.getValue(r, "note").toString();
-            Metrics m = new Metrics(timestamp, origin, category, type);
-            addMetricValues(m, mname, table.getValue(r, "value").toString(), note);
+            Metrics m = new Metrics(timestamp, origin, category);
+            m.set(mname, Numbers.parseNumber(table.getValue(r, "value")), note);
             metrics.add(m);
         }
         return this;
@@ -85,26 +84,6 @@ final public class BenchMetrics {
 
     void setName(String name) {
         this.name = name;
-    }
-
-    private String formatType(String type) {
-        var v = type.replace("java.lang:type=", "");
-        return v;
-    }
-
-    // init = 2113929216(2064384K) used = 133162344(130041K) committed = 570425344(557056K) max = 257698
-    // init = 7667712(7488K) used = 80316184(78433K) committed = 82771968(80832K) max = -1(-1K)
-    private void addMetricValues(Metrics metrics, String mname, String mvalue, String note) {
-        var regex = "^init = ([-]?[0-9]+).* used = ([-]?[0-9]+).* committed = ([-]?[0-9]+).* max = ([-]?[0-9]+).*$";
-        String[] vals = mvalue.replaceAll(regex, "$1,$2,$3,$4").split(",");
-        if (vals.length == 4) {
-            metrics.set(mname + " Init", Long.parseLong(vals[0]), note);
-            metrics.set(mname + " Used", Long.parseLong(vals[1]), note);
-            metrics.set(mname + " Committed", Long.parseLong(vals[2]), note);
-            metrics.set(mname + " Max", Long.parseLong(vals[3]), note);
-        } else {
-            metrics.set(mname, Numbers.parseNumber(mvalue), note);
-        }
     }
 
     private void assertColumnNames(ResultTable table) {

--- a/src/main/java/io/deephaven/benchmark/connect/BarrageConnector.java
+++ b/src/main/java/io/deephaven/benchmark/connect/BarrageConnector.java
@@ -109,7 +109,7 @@ public class BarrageConnector implements AutoCloseable {
      */
     public Future<Metrics> fetchSnapshotData(String table, Consumer<ResultTable> tableHandler) {
         checkClosed();
-        Metrics metrics = new Metrics("test-runner", table, "session");
+        Metrics metrics = new Metrics("test-runner", "session." + table);
         MetricsFuture future = new MetricsFuture(metrics);
         snapshots.computeIfAbsent(table, s -> {
             try {
@@ -142,7 +142,7 @@ public class BarrageConnector implements AutoCloseable {
      */
     public Future<Metrics> fetchTickingData(String table, Function<ResultTable, Boolean> tableHandler) {
         checkClosed();
-        Metrics metrics = new Metrics("test-runner", table, "session");
+        Metrics metrics = new Metrics("test-runner", "session." + table);
         MetricsFuture future = new MetricsFuture(metrics);
         subscriptions.computeIfAbsent(table, s -> {
             try {

--- a/src/main/java/io/deephaven/benchmark/generator/AvroKafkaGenerator.java
+++ b/src/main/java/io/deephaven/benchmark/generator/AvroKafkaGenerator.java
@@ -96,7 +96,7 @@ public class AvroKafkaGenerator implements Generator {
                     }
                 }
                 Log.info("Produced %s records to topic: %s", recCount, topic);
-                Metrics metrics = new Metrics("test-runner", topic, "generator").set("duration.secs", duration / 1000.0)
+                var metrics = new Metrics("test-runner", "generate." + topic).set("duration.secs", duration / 1000.0)
                         .set("record.count", recCount).set("send.rate", recCount / (duration / 1000.0));
                 return metrics;
             }

--- a/src/main/java/io/deephaven/benchmark/generator/JsonKafkaGenerator.java
+++ b/src/main/java/io/deephaven/benchmark/generator/JsonKafkaGenerator.java
@@ -93,7 +93,7 @@ public class JsonKafkaGenerator implements Generator {
                     }
                 }
                 producer.flush();
-                Metrics metrics = new Metrics("test-runner", topic, "generator").set("duration.secs", duration / 1000.0)
+                var metrics = new Metrics("test-runner", "generate." + topic).set("duration.secs", duration / 1000.0)
                         .set("record.count", recCount).set("send.rate", recCount / (duration / 1000.0))
                         .set("verified.record.count", admin.getMessageCount(topic));
                 return metrics;

--- a/src/main/java/io/deephaven/benchmark/generator/ProtobufKafkaGenerator.java
+++ b/src/main/java/io/deephaven/benchmark/generator/ProtobufKafkaGenerator.java
@@ -102,7 +102,7 @@ public class ProtobufKafkaGenerator implements Generator {
                     }
                 }
                 Log.info("Produced %s records to topic: %s", recCount, topic);
-                Metrics metrics = new Metrics("test-runner", topic, "generator").set("duration.secs", duration / 1000.0)
+                var metrics = new Metrics("test-runner", "generate." + topic).set("duration.secs", duration / 1000.0)
                         .set("record.count", recCount).set("send.rate", recCount / (duration / 1000.0));
                 return metrics;
             }

--- a/src/main/java/io/deephaven/benchmark/metric/Metrics.java
+++ b/src/main/java/io/deephaven/benchmark/metric/Metrics.java
@@ -13,7 +13,6 @@ public class Metrics {
     final long timestamp;
     final String origin;
     final String category;
-    final String type;
 
     /**
      * Initializes a newly created {@code Metrics} object representing a set of metrics that uses the current time for
@@ -23,8 +22,8 @@ public class Metrics {
      * @param category groups these metrics with other metrics
      * @param type identifies this set of metrics
      */
-    public Metrics(String origin, String category, String type) {
-        this(System.currentTimeMillis(), origin, category, type);
+    public Metrics(String origin, String category) {
+        this(System.currentTimeMillis(), origin, category);
     }
 
     /**
@@ -33,13 +32,11 @@ public class Metrics {
      * @param timestamp timestamp in millis since epoch the metric was taken
      * @param origin where the metrics came from (ex. myservice, myhost)
      * @param category groups these metrics with other metrics
-     * @param type identifies this set of metrics
      */
-    public Metrics(long timestamp, String origin, String category, String type) {
+    public Metrics(long timestamp, String origin, String category) {
         this.timestamp = timestamp;
         this.origin = origin;
         this.category = category;
-        this.type = type;
     }
 
     /**
@@ -82,8 +79,8 @@ public class Metrics {
         if (v == null || n == null)
             return null;
 
-        return Map.of("timestamp", timestamp, "origin", origin, "category", category, "type", type, "name", metricName,
-                "value", v, "note", n);
+        return Map.of("timestamp", timestamp, "origin", origin, "name", category + '.' + metricName, "value", v,
+                "note", n);
     }
 
     /**
@@ -113,7 +110,6 @@ public class Metrics {
         m.put("timestamp", timestamp);
         m.put("origin", origin);
         m.put("category", category);
-        m.put("type", type);
         m.putAll(metrics);
         return m.toString();
     }

--- a/src/main/java/io/deephaven/benchmark/util/Ids.java
+++ b/src/main/java/io/deephaven/benchmark/util/Ids.java
@@ -1,18 +1,14 @@
 /* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.util;
 
-import java.math.BigInteger;
-import java.util.Base64;
+import java.time.Instant;
 import java.util.Random;
 
 /**
  * Provide unique Ids for file naming
  */
 public class Ids {
-    static final long years50 = 1577847600000L;
     static final Random random = new Random();
-    static private long count = 0;
-    static private long lastTime = now50();
 
     /**
      * Replace any characters in the given name that may not be safe to use as a file name
@@ -30,7 +26,7 @@ public class Ids {
      * @return a time-based id
      */
     static public String runId() {
-        return "run-" + Long.toHexString(now50());
+        return "run-" + nowBase62();
     }
 
     /**
@@ -40,7 +36,7 @@ public class Ids {
      * @return true if it looks like a runId, otherwise false
      */
     static public boolean isRunId(Object id) {
-        return id.toString().matches("run-[a-z0-9]{10,16}");
+        return id.toString().matches("run-[0-9A-Za-z]+");
     }
 
     /**
@@ -48,17 +44,10 @@ public class Ids {
      * 
      * @return the unique name
      */
-    static public String uniqueName() {
-        long now = now50();
-        if (now > lastTime) {
-            lastTime = now;
-            count = 0;
-        }
-
-        String time = toBase64(now);
-        String cnt = Long.toHexString(++count);
-        String rand = toBase64(random.nextInt());
-        return time + '.' + cnt + '.' + rand;
+    static public String uniqueName(String prefix) {
+        String time = nowBase62();
+        String rand = Numbers.toBase62(Math.abs(random.nextInt()));
+        return String.join(".", prefix, time, rand);
     }
 
     /**
@@ -75,19 +64,9 @@ public class Ids {
         return h;
     }
 
-    /**
-     * Convert long to URL base64
-     * 
-     * @param num the number to convert
-     * @return a base64 string representing the given number
-     */
-    static String toBase64(long num) {
-        String s = Base64.getUrlEncoder().encodeToString(BigInteger.valueOf(num).toByteArray());
-        return s.replace("=", "");
-    }
-
-    static long now50() {
-        return System.currentTimeMillis() - years50;
+    static String nowBase62() {
+        var now = Instant.now();
+        return Numbers.toBase62(String.format("%d%03d", now.getEpochSecond(), now.getNano() / 1000000));
     }
 
 }

--- a/src/main/java/io/deephaven/benchmark/util/Numbers.java
+++ b/src/main/java/io/deephaven/benchmark/util/Numbers.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.util;
 
+import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.util.regex.Pattern;
 
@@ -132,6 +133,38 @@ public class Numbers {
         var num = parseNumber(split[1]).longValue();
         num = offset + size - num + offset;
         return split[0] + num + split[2];
+    }
+
+    /**
+     * Convert a positive integral to Base 62
+     * 
+     * @param num the number to convert
+     * @return a base58 string representing of the given number
+     */
+    static public String toBase62(Number num) {
+        return toBase62(num.toString());
+    }
+
+    /**
+     * Convert a Base 10 string to Base 62. Accepted values are positive digits.
+     * <p/>
+     * Note: The results of this method should match the results of <code>./github/scripts/base58.sh exactly</code>
+     * 
+     * @param num the number to convert
+     * @return a base64 string representing the given number
+     */
+    static public String toBase62(String num) {
+        var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+        var num10 = new BigInteger(num, 10);
+        var big62 = BigInteger.valueOf(62);
+        var big0 = BigInteger.valueOf(0);
+        var str62 = new StringBuilder();
+        do {
+            var div = num10.divideAndRemainder(big62);
+            str62.insert(0, chars.charAt(div[1].intValue()));
+            num10 = div[0];
+        } while (num10.compareTo(big0) > 0);
+        return str62.toString();
     }
 
 }

--- a/src/main/resources/io/deephaven/benchmark/run/profile/benchmark_tables.dh.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/benchmark_tables.dh.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending 
+# Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending 
 #
 # Deephaven query to run against historical benchmark data stored in GCloud bucket and produce
 # some useful correlated tables
@@ -13,31 +13,54 @@ from urllib.request import urlopen, urlretrieve
 s_results = {'benchmark_name':dht.string, 'origin':dht.string,'timestamp':dht.long,'test_duration':dht.double,
     'op_duration':dht.double,'op_rate':dht.long,'row_count':dht.long}
 
+# Convert the given name to a name suitable for a DH column name
+def normalize_name(name):
+    name = name.replace('/','__')
+    return re.sub('[^A-Za-z0-9_$]', '_', name)
+
 # Get the latest GCloud run_ids for the benchmark category up to max_runs
-def get_remote_run_ids(parent_uri, category, max_runs=10):
+def get_remote_children(parent_uri, category, max_runs=10):
     run_ids = []
     search_uri = parent_uri + '?delimiter=/&prefix=' + category + '/' + '&max-keys=100000'
     with urlopen(search_uri) as r:
         text = r.read().decode()
-        for run_id in re.findall('<Prefix>{}/run-([a-z0-9]+)/</Prefix>'.format(category), text, re.MULTILINE):
+        for run_id in re.findall('<Prefix>{}/([^/><]+)/</Prefix>'.format(category), text, re.MULTILINE):
             run_ids.append(run_id)
     run_ids.sort(reverse=True)
     return run_ids[:max_runs]
     
 # Get the latest file-based run_ids for the benchmark category up to max_runs
-def get_local_run_ids(parent_uri, category, max_runs=10):
+def get_local_children(parent_uri, category, max_runs=10):
     run_ids = []
-    text = os.linesep.join(glob.glob(parent_uri.replace('file://','') + '/' + category + '/run-*'))
-    for run_id in re.findall('.*/run-([a-z0-9]+)'.format(category), text, re.MULTILINE):
+    root_path = parent_uri.replace('file:///','/')
+    for run_id in os.listdir(os.path.normpath(os.path.join(root_path, category))):
         run_ids.append(run_id)
     run_ids.sort(reverse=True)
     return run_ids[:max_runs]
     
-def get_run_ids(storage_uri, category, max_runs):
+def get_children(storage_uri, category, max_runs):
     if storage_uri.startswith('http'):
-        return get_remote_run_ids(storage_uri, category, max_runs)
+        return get_remote_children(storage_uri, category, max_runs)
     else: 
-        return get_local_run_ids(storage_uri, category, max_runs)
+        return get_local_children(storage_uri, category, max_runs)
+        
+def get_run_paths(storage_uri, category, actor_filter, set_filter, max_set=10):
+    print('get_run_paths', storage_uri, category, actor_filter, set_filter, max_set)
+    set_matcher = re.compile(set_filter)
+    actor_matcher = re.compile(actor_filter)
+    benchmark_sets = []
+    for actor in get_children(storage_uri, category, 1000):
+        if actor_matcher.match(actor): 
+            for set_label in get_children(storage_uri, category + '/' + actor, 1000):
+                if set_matcher.match(set_label): 
+                    benchmark_sets.append(actor + '/' + set_label)
+    benchmark_sets.sort(reverse=True)
+    benchmark_sets = benchmark_sets[:max_sets]
+    benchmark_runs = []
+    for set_path in benchmark_sets:
+        for run_id in get_children(storage_uri, category + '/' + set_path, 1000):
+            benchmark_runs.append(set_path + '/' + run_id)
+    return benchmark_runs
 
 # Cache an HTTP url into a local directory and return the local path  
 def cache_remote_csv(uri):
@@ -79,61 +102,60 @@ def dh_read_csv(uri, schema=None):
 def merge_run_tables(parent_uri, run_ids, category, csv_file_name, schema = None):
     tables = []
     for run_id in run_ids:
-        table_uri = parent_uri + '/' + category + '/run-' + run_id + '/' + csv_file_name
+        table_uri = parent_uri + '/' + category + '/' + run_id + '/' + csv_file_name
         table_csv = dh_read_csv(table_uri, schema)
-        table_csv = table_csv.update_view(['run_id = "' + run_id + '"'])
+        set_id = os.path.dirname(run_id)
+        run_id = os.path.basename(run_id)
+        table_csv = table_csv.update_view(['set_id = "' + set_id + '"', 'run_id = "' + run_id + '"'])
         tables.append(table_csv)
     return merge(tables)
 
 # Load standard tables from GCloud or local storage according to category
 # If this script is run from exec(), accept the benchmark_category_arg
 default_storage_uri = 'https://storage.googleapis.com/deephaven-benchmark'
-default_category = 'ZTEST'
-default_max_runs = 5
+default_category = 'adhoc'
+default_max_sets = 5
 default_history_runs = 5
+default_actor_filter = '.*'
+default_set_filter = '.*'
+default_platform_props = []
+default_metric_props = []
 
 storage_uri = benchmark_storage_uri_arg if 'benchmark_storage_uri_arg' in globals() else default_storage_uri
 category = benchmark_category_arg if 'benchmark_category_arg' in globals() else default_category
-max_runs = benchmark_max_runs_arg if 'benchmark_max_runs_arg' in globals() else default_max_runs
+max_sets = benchmark_max_sets_arg if 'benchmark_max_sets_arg' in globals() else default_max_sets
 history_runs = benchmark_history_runs_arg if 'benchmark_history_runs_arg' in globals() else default_history_runs
-run_ids = get_run_ids(storage_uri, category, max_runs)
+actor_filter = benchmark_actor_filter_arg if 'benchmark_actor_filter_arg' in globals() else default_actor_filter
+set_filter = benchmark_set_filter_arg if 'benchmark_set_filter_arg' in globals() else default_set_filter
+platform_props = benchmark_platform_props_arg if 'benchmark_platform_props_arg' in globals() else default_platform_props
+metric_props = benchmark_metric_props_arg if 'benchmark_metric_props_arg' in globals() else default_metric_props
+run_ids = get_run_paths(storage_uri, category, actor_filter, set_filter, max_sets)
+
 bench_results = merge_run_tables(storage_uri, run_ids, category, 'benchmark-results.csv', s_results)
 bench_metrics = merge_run_tables(storage_uri, run_ids, category, 'benchmark-metrics.csv')
 bench_platforms = merge_run_tables(storage_uri, run_ids, category, 'benchmark-platform.csv')
 
-# Make diff between first and last metrics samples
-bench_metrics_diff = bench_metrics.agg_by(
-    aggs=[agg.first('first_value=value'), agg.last('last_value=value')], 
-    by=['run_id', 'benchmark_name', 'origin', 'category', 'type', 'name'])
-bench_metrics_diff = bench_metrics_diff.view(
-    ['run_id', 'benchmark_name', 'origin', 'category', 'type', 'name', 'value_diff=last_value-first_value']
-)
+def add_platform_values(table, pnames=[], cnames = []):
+    pnames = list(dict.fromkeys(pnames))
+    for pname in pnames:
+        new_pname = normalize_name(pname)
+        cnames.append(new_pname)
+        single_platforms = bench_platforms.where(['name=pname']).first_by(['set_id','run_id','origin'])
+        table = table.natural_join(
+            single_platforms, on=['set_id','run_id','origin'], joins=[new_pname+'=value']
+        )
+    return table
 
-# Create a table with useful diff metrics joined into the benchmark results
-bench_results_diff = bench_results
-def add_metric_value_diff(mcategory, mtype, mname, new_mname):
-    global bench_results_diff
-    single_metrics = bench_metrics_diff.where(['category=mcategory', 'type=mtype', 'name=mname'])
-    bench_results_diff = bench_results_diff.exact_join(
-        single_metrics, on=['run_id', 'benchmark_name', 'origin'], joins=[new_mname+'=value_diff']
-    )
-
-def add_platform_value(pname, new_pname):
-    global bench_results_diff
-    single_platforms = bench_platforms.where(['name=pname'])
-    bench_results_diff = bench_results_diff.exact_join(
-        single_platforms, on=['run_id', 'origin'], joins=[new_pname+'=value']
-    )
-
-add_platform_value('deephaven.version', 'deephaven_version')
-add_metric_value_diff('MemoryImpl', 'Memory', 'HeapMemoryUsage Used', "heap_used")
-add_metric_value_diff('MemoryImpl', 'Memory', 'NonHeapMemoryUsage Used', "non_heap_used")
-add_metric_value_diff('MemoryImpl', 'Memory', 'HeapMemoryUsage Committed', 'heap_committed')
-add_metric_value_diff('MemoryImpl', 'Memory', 'NonHeapMemoryUsage Committed', 'non_heap_committed')
-add_metric_value_diff('GarbageCollectorExtImpl', 'G1 Young Generation', 'CollectionCount', 'g1_young_collect_count')
-add_metric_value_diff('GarbageCollectorExtImpl', 'G1 Young Generation', 'CollectionTime', 'g1_young_collect_time')
-add_metric_value_diff('GarbageCollectorExtImpl', 'G1 Old Generation', 'CollectionCount', 'g1_old_collect_count')
-add_metric_value_diff('GarbageCollectorExtImpl', 'G1 Old Generation', 'CollectionTime', 'g1_old_collect_time')
+def add_metric_values(table, pnames=[], cnames=[]):
+    pnames = list(dict.fromkeys(pnames))
+    for pname in pnames:
+        new_pname = normalize_name(pname)
+        cnames.append(new_pname)
+        single_metrtics = bench_metrics.where(['name=pname']).first_by(['benchmark_name','set_id','run_id','origin'])
+        table = table.natural_join(
+            single_metrtics, on=['benchmark_name','set_id','run_id','origin'], joins=[new_pname+'=value']
+        )
+    return table
 
 import statistics
 def rstd(rates) -> float:
@@ -168,17 +190,33 @@ def truncate(text, size):
     if len(text) < size - 3: return text
     return text[:size-3] + '...'
 
+def mid_item(arr):
+    n = len(arr)
+    return arr[n // 2]
+
 # Create a table showing percentage variability and change in rates
 from deephaven.updateby import rolling_group_tick
 op_group = rolling_group_tick(cols=["op_group_rates = op_rate"], rev_ticks=history_runs, fwd_ticks=0)
 op_version = rolling_group_tick(cols=["op_group_versions = deephaven_version"], rev_ticks=history_runs, fwd_ticks=0)
 
-bench_results_change = bench_results_diff.sort(['benchmark_name', 'origin', 'deephaven_version', 'timestamp'])
-bench_results_change = bench_results_change.update_by(ops=[op_group, op_version], by=['benchmark_name', 'origin'])
-bench_results_change = bench_results_change.update_view(
-    ['op_rate_variability=(float)rstd(op_group_rates)', 'op_rate_change=(float)rchange(op_group_rates)']
-)
-bench_results_change = bench_results_change.view(
-    ['benchmark_name', 'origin', 'timestamp', 'deephaven_version', 'op_duration', 'op_rate', 
-    'op_rate_variability', 'op_rate_change', 'op_rate_change', 'op_group_rates', 'op_group_versions']
-)
+bench_results_change = bench_results.sort(['benchmark_name','origin','set_id','op_rate']) \
+    .group_by(['benchmark_name','origin','set_id']) \
+    .view([
+        'benchmark_name','origin','timestamp=(long)mid_item(timestamp)','test_duration=(double)mid_item(test_duration)',
+        'op_duration=(double)mid_item(op_duration)','op_rate=(long)mid_item(op_rate)','row_count=(long)mid_item(row_count)',
+        'set_id','run_id=(String)mid_item(run_id)'
+    ])
+
+local_platform_props = []
+local_metric_props = []
+bench_results_change = add_platform_values(bench_results_change, ['deephaven.version'] + platform_props, local_platform_props)
+bench_results_change = add_metric_values(bench_results_change, metric_props, local_metric_props)
+
+bench_results_change = bench_results_change.sort(['benchmark_name', 'origin', 'deephaven_version', 'set_id']) \
+    .update_by(ops=[op_group, op_version], by=['benchmark_name', 'origin']) \
+    .update_view(['op_rate_variability=(float)rstd(op_group_rates)', 'op_rate_change=(float)rchange(op_group_rates)']) \
+    .view(['benchmark_name', 'origin', 'timestamp'] + local_platform_props + local_metric_props +
+        ['deephaven_version', 'op_duration', 'op_rate', 'op_rate_variability', 'op_rate_change', 'op_rate_change', 
+        'op_group_rates', 'op_group_versions'          
+    ])
+

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/publish.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/publish.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending 
+# Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending 
 #
 # Supporting Deephaven queries to use the benchmark_snippet to investigate changes between nightly benchmarks
 # - Make two tables; one cryptic and small, the other clearer with more rows
@@ -8,21 +8,20 @@ from urllib.request import urlopen; import os
 root = 'file:///nfs' if os.path.exists('/nfs/deephaven-benchmark') else 'https://storage.googleapis.com'
 with urlopen(root + '/deephaven-benchmark/benchmark_tables.dh.py') as r:
     benchmark_storage_uri_arg = root + '/deephaven-benchmark'
-    benchmark_category_arg = 'nightly'  # release | nightly    
-    benchmark_max_runs_arg = 45  # Latest X runs to include   
+    benchmark_category_arg = 'nightly'  # release | nightly
+    benchnark_max_sets_arg = 45
+    benchmark_actor_filter_arg = 'deephaven'
+    benchmark_set_filter_arg = '[0-9]{4}([-][0-9]{2}){2}'  # yyyy-mm-dd
     exec(r.read().decode(), globals(), locals())
-
-# Used to provide platform (e.g. hardware, jvm version) for SVG footer during publish
-platform_details = bench_platforms.sort_descending(['run_id']).group_by(['run_id']).first_by().ungroup()
 
 # Return a table containing only non-obsolete benchmarks having at least two of the most recent versions
 # Candidate for pulling up into deephaven_tables.py
 def latest_comparable_benchmarks(filter_table):
-    latest_benchmark_names = bench_results.view([
-        'run_id','benchmark_name'
-    ]).group_by(['run_id']).sort_descending(['run_id']).first_by().ungroup()
+    latest_benchmark_names = bench_results_sets.view([
+        'set_id','benchmark_name'
+    ]).group_by(['set_id']).sort_descending(['set_id']).first_by().ungroup()
 
-    new_benchmark_names = bench_results.where_in(
+    new_benchmark_names = bench_results_sets.where_in(
         latest_benchmark_names,['benchmark_name=benchmark_name']
     ).group_by(['benchmark_name']).where(['len(op_rate) < 2']).ungroup()
 
@@ -33,73 +32,62 @@ def latest_comparable_benchmarks(filter_table):
     )
     return results_tbl
     
-bench_results = latest_comparable_benchmarks(bench_results)
+bench_results = latest_comparable_benchmarks(bench_results_sets)
 
 # Get static benchmarks and compare to last 5 days and previous release
-nightly_score = bench_results.where([
-    'benchmark_name.endsWith(`-Static`)'
-]).exact_join(
-    bench_platforms.where(['name=`deephaven.version`']),
-    on=['run_id', 'origin'], joins=['deephaven_version=value']
-).sort_descending([
-    'benchmark_name','timestamp','deephaven_version','origin'
-]).group_by([
-    'benchmark_name','deephaven_version','origin'
-]).head_by(2, [
-    'benchmark_name','origin'
-]).group_by([
-    'benchmark_name','origin'
-]).update([
-    'all_rates=vec(concat(op_rate[0],op_rate[1]))',  
-    'all_past_rates=all_rates.subVector(1,len(all_rates))',
-    'past_5_rates=all_past_rates.subVector(0,6)',
-    'last_5_prev_vers_rates=ifelseObj(op_rate[1]!=null,op_rate[1],op_rate[0]).subVector(0,6)',
-    'op_rate=all_rates[0]','var_rate=rstd(past_5_rates)',
-    'avg_rate=avg(past_5_rates)','prev_vers_avg_rate=avg(last_5_prev_vers_rates)',
-    'score=zscore(op_rate,past_5_rates)',
-    'prev_vers_score=zscore(op_rate,last_5_prev_vers_rates)',
-    'prob=zprob(score)'
-])
+nightly_score = bench_results.where(['benchmark_name.endsWith(`-Static`)']) \
+    .sort_descending(['benchmark_name','timestamp','deephaven_version','origin']) \
+    .group_by(['benchmark_name','deephaven_version','origin']) \
+    .head_by(2, ['benchmark_name','origin']) \
+    .group_by(['benchmark_name','origin']) \
+    .update(['all_rates=vec(concat(op_rate[0],op_rate[1]))',
+        'all_past_rates=all_rates.subVector(1,len(all_rates))',
+        'past_5_rates=all_past_rates.subVector(0,6)', 
+        'last_5_prev_vers_rates=ifelseObj(op_rate[1]!=null,op_rate[1],op_rate[0]).subVector(0,6)',
+        'op_rate=all_rates[0]','var_rate=rstd(past_5_rates)',
+        'avg_rate=avg(past_5_rates)','prev_vers_avg_rate=avg(last_5_prev_vers_rates)',
+        'score=zscore(op_rate,past_5_rates)',
+        'prev_vers_score=zscore(op_rate,last_5_prev_vers_rates)',
+        'prob=zprob(score)'])
 
-nightly_worst_score_large = nightly_score.view([
-    'Static_Benchmark=benchmark_name.replace(` -Static`,``)',
-    'Variability=var_rate/100','Rate=op_rate',
-    'Change=gain(avg_rate,op_rate)/100',
-    'Since_Release=gain(prev_vers_avg_rate,op_rate)/100',
-    'Score=score','Score_Prob=prob'
-]).sort(['Score']).head_by(20).format_columns([
-    'Variability=Decimal(`0.0%`)','Rate=Decimal(`###,##0`)',
-    'Change=Decimal(`0.0%`)','Since_Release=Decimal(`0.0%`)',
-    'Score=Decimal(`0.0`)','Score_Prob=Decimal(`0.00%`)'
-])
+nightly_worst_score_large = nightly_score \
+    .view(['Static_Benchmark=benchmark_name.replace(` -Static`,``)',
+        'Variability=var_rate/100','Rate=op_rate',
+        'Change=gain(avg_rate,op_rate)/100',
+        'Since_Release=gain(prev_vers_avg_rate,op_rate)/100',
+        'Score=score','Score_Prob=prob']) \
+    .sort(['Score']) \
+    .head_by(20) \
+    .format_columns(['Variability=Decimal(`0.0%`)','Rate=Decimal(`###,##0`)',
+        'Change=Decimal(`0.0%`)','Since_Release=Decimal(`0.0%`)',
+        'Score=Decimal(`0.0`)','Score_Prob=Decimal(`0.00%`)'])
 
-nightly_worst_score_small = nightly_worst_score_large.head_by(10).view([
-    'Static_Benchmark=truncate(Static_Benchmark,50)','Chng5d=Change',
-    'Var5d=Variability','Rate','ChngRls=Since_Release','Scr=Score','ScrProb=Score_Prob'   
-]).format_columns([
-    'Rate=Decimal(`###,##0`)','Chng5d=Decimal(`0.0%`)','Var5d=Decimal(`0.0%`)',
-    'ChngRls=Decimal(`0.0%`)','Scr=Decimal(`0.0`)','ScrProb=Decimal(`0.00%`)'
-])
+nightly_worst_score_small = nightly_worst_score_large \
+    .head_by(10) \
+    .view(['Static_Benchmark=truncate(Static_Benchmark,50)','Chng5d=Change',
+        'Var5d=Variability','Rate','ChngRls=Since_Release','Scr=Score','ScrProb=Score_Prob']) \
+    .format_columns(['Rate=Decimal(`###,##0`)','Chng5d=Decimal(`0.0%`)','Var5d=Decimal(`0.0%`)',
+        'ChngRls=Decimal(`0.0%`)','Scr=Decimal(`0.0`)','ScrProb=Decimal(`0.00%`)'])
 
-nightly_best_score_large = nightly_score.view([
-    'Static_Benchmark=benchmark_name.replace(` -Static`,``)',
-    'Variability=var_rate/100','Rate=op_rate',
-    'Change=gain(avg_rate,op_rate)/100',
-    'Since_Release=gain(prev_vers_avg_rate,op_rate)/100',
-    'Score=score','Score_Prob=prob'
-]).sort_descending(['Score']).head_by(20).format_columns([
-    'Variability=Decimal(`0.0%`)','Rate=Decimal(`###,##0`)',
-    'Change=Decimal(`0.0%`)','Since_Release=Decimal(`0.0%`)',
-    'Score=Decimal(`0.0`)','Score_Prob=Decimal(`0.00%`)'
-])
+nightly_best_score_large = nightly_score \
+    .view(['Static_Benchmark=benchmark_name.replace(` -Static`,``)',
+        'Variability=var_rate/100','Rate=op_rate',
+        'Change=gain(avg_rate,op_rate)/100',
+        'Since_Release=gain(prev_vers_avg_rate,op_rate)/100',
+        'Score=score','Score_Prob=prob']) \
+    .sort_descending(['Score']) \
+    .head_by(20) \
+    .format_columns(['Variability=Decimal(`0.0%`)','Rate=Decimal(`###,##0`)',
+        'Change=Decimal(`0.0%`)','Since_Release=Decimal(`0.0%`)',
+        'Score=Decimal(`0.0`)','Score_Prob=Decimal(`0.00%`)'])
 
-nightly_best_score_small = nightly_best_score_large.head_by(10).view([
-    'Static_Benchmark=truncate(Static_Benchmark,50)','Chng5d=Change',
-    'Var5d=Variability','Rate','ChngRls=Since_Release','Scr=Score','ScrProb=Score_Prob'   
-]).format_columns([
-    'Rate=Decimal(`###,##0`)','Chng5d=Decimal(`0.0%`)','Var5d=Decimal(`0.0%`)',
-    'ChngRls=Decimal(`0.0%`)','Scr=Decimal(`0.0`)','ScrProb=Decimal(`0.00%`)'
-])
+nightly_best_score_small = nightly_best_score_large \
+    .head_by(10) \
+    .view(['Static_Benchmark=truncate(Static_Benchmark,50)','Chng5d=Change',
+        'Var5d=Variability','Rate','ChngRls=Since_Release','Scr=Score','ScrProb=Score_Prob']) \
+    .format_columns(['Rate=Decimal(`###,##0`)','Chng5d=Decimal(`0.0%`)','Var5d=Decimal(`0.0%`)',
+        'ChngRls=Decimal(`0.0%`)','Scr=Decimal(`0.0`)','ScrProb=Decimal(`0.00%`)'])
 
 bench_results = bench_metrics = bench_platforms = bench_metrics_diff = None
 bench_results_change = bench_results_diff = None
+

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/release.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/release.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending 
+# Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending 
 #
 # Supporting Deephaven queries to use the benchmark_snippet to investigate changes between releases
 # - Generate tables for best and wost static rates between the latest release and previous
@@ -7,11 +7,13 @@
 
 from urllib.request import urlopen; import os
 
-root = 'file:///nfs' if os.path.exists('/nfs/deephaven-benchmark') else 'https://storage.googleapis.com'
+root = 'file:///data' if os.path.exists('/data/deephaven-benchmark') else 'https://storage.googleapis.com'
 with urlopen(root + '/deephaven-benchmark/benchmark_tables.dh.py') as r:
     benchmark_storage_uri_arg = root + '/deephaven-benchmark'
-    benchmark_category_arg = 'release'  # release | nightly    
-    benchmark_max_runs_arg = 5  # Latest X runs to include   
+    benchmark_category_arg = 'release'  # release | nightly
+    benchmark_max_sets_arg = 5
+    benchmark_actor_filter_arg = 'deephaven'
+    benchmark_set_filter_arg = '[0-9]{2}[.][0-9]{3}[.][0-9]{2}'
     exec(r.read().decode(), globals(), locals())
 
 # Replace any characters that are illegal in DH column names
@@ -22,11 +24,11 @@ def column_name(name):
 # Return a table containing only non-obsolete benchmarks having at least two of the most recent versions
 # Candidate for pulling up into deephaven_tables.py
 def latest_comparable_benchmarks(filter_table):
-    latest_benchmark_names = bench_results.view([
-        'run_id','benchmark_name'
-    ]).group_by(['run_id']).sort_descending(['run_id']).first_by().ungroup()
+    latest_benchmark_names = bench_results_sets.view([
+        'set_id','benchmark_name'
+    ]).group_by(['set_id']).sort_descending(['set_id']).first_by().ungroup()
 
-    new_benchmark_names = bench_results.where_in(
+    new_benchmark_names = bench_results_sets.where_in(
         latest_benchmark_names,['benchmark_name=benchmark_name']
     ).group_by(['benchmark_name']).where(['len(op_rate) < 2']).ungroup()
 
@@ -37,32 +39,23 @@ def latest_comparable_benchmarks(filter_table):
     )
     return results_tbl
 
-newest_benchmarks = latest_comparable_benchmarks(bench_results_change).sort_descending(['timestamp']).first_by(['benchmark_name'])
+newest_benchmarks = latest_comparable_benchmarks(bench_results_sets).sort_descending(['set_id'])
+
+vers_tbl = newest_benchmarks.view(["deephaven_version"])
 
 from deephaven import numpy as dhnp
-
-versions = {}
-version_vectors = dhnp.to_numpy(newest_benchmarks.view(["op_group_versions"]))
-for vector in version_vectors:
-    for vers in vector:
-        for v in vers.toArray():
-            versions['V_' + column_name(v)] = 0
-vers = list(versions.keys())
-vers.reverse()
+vers = dhnp.to_numpy(newest_benchmarks.view(["deephaven_version"]).first_by())
+print("Vers: ", vers)
 versLen = len(vers)
+vers = [normalize_name(ver) for ver in vers]
 
-past_static_rates = newest_benchmarks.where([
-    'benchmark_name.endsWith(`-Static`)'
-]).update([
-    'op_group_rates=vec(reverse(op_group_rates)).subVector(0, versLen)',
-    'op_group_versions=vecObj(reverseObj(op_group_versions)).subVector(0, versLen)',
-    'Change=gain(op_group_rates[1], op_group_rates[0])'
-]).update([
-    (vers[i] + "=op_group_rates[" + str(i) + "]") for i in range(versLen)
-]).view([
-    'Static_Benchmark=benchmark_name.replace(` -Static`,``)',
-    'Duration=op_duration','Variability=op_rate_variability','Change'] + [
-    vers[i] for i in range(versLen)
+past_static_rates = newest_benchmarks.where(['benchmark_name.endsWith(`-Static`)']) \
+    .group_by(['benchmark_name','origin','set_id']) \
+    .update(['Change=gain(op_rate[1], op_rate[0])']) \
+    .update([(vers[i] + "=op_rate[" + str(i) + "]") for i in range(versLen)]) \
+    .view(['Static_Benchmark=benchmark_name.replace(` -Static`,``)',
+        'Duration=op_duration[0]','Variability=variability[0]','Change'] + 
+        [vers[i] for i in range(versLen)
 ])
 
 worst_static_rate_changes = past_static_rates.sort(['Change']).head_by(25)

--- a/src/test/java/io/deephaven/benchmark/metric/MetricsTest.java
+++ b/src/test/java/io/deephaven/benchmark/metric/MetricsTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.*;
 public class MetricsTest {
     @Test
     public void set() {
-        Metrics m = new Metrics("origin1", "type1", "cat1");
+        Metrics m = new Metrics("origin1", "cat1");
         m.set("mname1", 1);
         assertEquals(1, m.getValue("mname1"), "Wrong metric value");
         assertNull(m.getValue("missing"), "Metric should be missing");
@@ -19,25 +19,25 @@ public class MetricsTest {
 
     @Test
     public void tostring() {
-        Metrics m = new Metrics(123, "o1", "c1", "t1");
-        assertEquals("{timestamp=123, origin=o1, category=c1, type=t1}", m.toString(), "Wrong toString");
+        Metrics m = new Metrics(123, "o1", "c1");
+        assertEquals("{timestamp=123, origin=o1, category=c1}", m.toString(), "Wrong toString");
         m.set("n1", 10);
-        assertEquals("{timestamp=123, origin=o1, category=c1, type=t1, n1=10}", m.toString(), "Wrong toString");
+        assertEquals("{timestamp=123, origin=o1, category=c1, n1=10}", m.toString(), "Wrong toString");
         m.set("n1", 10, "n1", "n2");
-        assertEquals("{timestamp=123, origin=o1, category=c1, type=t1, n1=10;n1;n2}", m.toString(), "Wrong toString");
+        assertEquals("{timestamp=123, origin=o1, category=c1, n1=10;n1;n2}", m.toString(), "Wrong toString");
     }
 
     @Test
     public void getMetric() {
-        Metrics m = new Metrics(123, "o1", "c1", "t1");
+        Metrics m = new Metrics(123, "o1", "c1");
         m.set("n1", 10);
         var r = new TreeMap<>(m.getMetric("n1")).toString();
-        assertEquals("{category=c1, name=n1, note=, origin=o1, timestamp=123, type=t1, value=10}", r,
+        assertEquals("{name=c1.n1, note=, origin=o1, timestamp=123, value=10}", r,
                 "Wrong map result");
 
         m.set("n1", 10, "n1", "n2");
         r = new TreeMap<>(m.getMetric("n1")).toString();
-        assertEquals("{category=c1, name=n1, note=n1;n2, origin=o1, timestamp=123, type=t1, value=10}", r,
+        assertEquals("{name=c1.n1, note=n1;n2, origin=o1, timestamp=123, value=10}", r,
                 "Wrong map result");
     }
 

--- a/src/test/java/io/deephaven/benchmark/run/SvgSummaryTest.java
+++ b/src/test/java/io/deephaven/benchmark/run/SvgSummaryTest.java
@@ -35,9 +35,9 @@ public class SvgSummaryTest {
                   </thead>
                   <tbody>
                     <tr><td>Avg By Row1</td><td>14,915,478</td><td>9,609,994</td></tr>
-                    <tr><td>Median By Row2</td><td>2,409,348</td><td>2,226,799</td></tr>
+                    <tr><td>Median By Row2</td><td>2,309,348</td><td>2,226,799</td></tr>
                     <tr><td>Avg By Row1</td><td>14,915,478</td><td>9,609,994</td></tr>
-                    <tr><td>Median By Row2</td><td>2,409,348</td><td>2,226,799</td></tr>
+                    <tr><td>Median By Row2</td><td>2,309,348</td><td>2,226,799</td></tr>
                   </tbody>
                   <tfoot><tr><td colspan="3">* threads=16 heap=24g os=ubuntu-22.04.1-lts benchmark-count=5</td></tr></tfoot>
                 </table>

--- a/src/test/java/io/deephaven/benchmark/util/IdsTest.java
+++ b/src/test/java/io/deephaven/benchmark/util/IdsTest.java
@@ -7,43 +7,43 @@ import org.junit.jupiter.api.*;
 
 public class IdsTest {
     @Test
-    public void uniqueName() {
+    void uniqueName() {
         var ids = new LinkedHashSet<String>();
         int count = 100000;
         for (int i = 0; i < count; i++) {
-            ids.add(Ids.uniqueName());
+            ids.add(Ids.uniqueName("p"));
         }
         assertEquals(count, ids.size(), "Wrong unique count");
 
         for (String id : ids) {
-            assertTrue(id.matches("[A-Za-z0-9_-]+[.][a-f0-9]+[.][A-Za-z0-9_-]+"), "Wrong id format");
+            assertTrue(id.matches("p[.][A-Za-z0-9]+[.][A-Za-z0-9]+"), "Wrong id format");
         }
     }
 
     @Test
-    public void getFileSafeName() {
+    void getFileSafeName() {
         assertEquals("This_is_a_test", Ids.getFileSafeName("This is a test"), "Wrong safe name");
     }
 
     @Test
-    public void runIds() {
+    void runIds() {
         String id = Ids.runId();
-        assertTrue(id.matches("run-[a-z0-9]{10,11}"), "Bad run id: " + id);
+        assertTrue(id.matches("run-[0-9A-Za-z]{7}"), "Bad run id: " + id);
     }
 
     @Test
-    public void isRunId() {
+    void isRunId() {
         String recent = "run-1619d760fa";
         String max = "run-7ffffe90a0f44c7f";
 
-        assertFalse(Ids.isRunId("run-abcdefghi"), "Should not be valid id");
+        assertFalse(Ids.isRunId("run-abcdefghi-id"), "Should not be valid id");
         assertFalse(Ids.isRunId("1619d1a435"), "Should not be valid id");
         assertTrue(Ids.isRunId(recent), "Should be valid id");
         assertTrue(Ids.isRunId(max), "Should be valid id");
     }
 
     @Test
-    public void hash64() {
+    void hash64() {
         assertEquals(65, Ids.hash64("A"));
         assertEquals(59610663905L, Ids.hash64("AAAAAAA"));
         assertEquals(5448659364008734959L, Ids.hash64("col1:int:[1-100]"));

--- a/src/test/java/io/deephaven/benchmark/util/NumbersTest.java
+++ b/src/test/java/io/deephaven/benchmark/util/NumbersTest.java
@@ -2,6 +2,7 @@
 package io.deephaven.benchmark.util;
 
 import static org.junit.jupiter.api.Assertions.*;
+import java.math.BigInteger;
 import org.junit.jupiter.api.*;
 
 public class NumbersTest {
@@ -70,6 +71,22 @@ public class NumbersTest {
         assertEquals("4s", Numbers.offsetInString("1s", 0, 5));
         assertEquals("1s", Numbers.offsetInString("4s", 0, 5));
         assertEquals("s170s", Numbers.offsetInString("s130s", 100, 100));
+    }
+
+    @Test
+    void toBase62() {
+        assertEquals("UGHMJMK", Numbers.toBase62("1718921708180"));
+        assertEquals("UGHOiO9", Numbers.toBase62("1718922281049"));
+        assertEquals("UGHOv6n", Numbers.toBase62("1718922329945"));
+        assertEquals("1", Numbers.toBase62("1"));
+        assertEquals("A", Numbers.toBase62("10"));
+        assertEquals("G8", Numbers.toBase62("1000"));
+        assertEquals("Q0u", Numbers.toBase62("100000"));
+        assertEquals("fxSK", Numbers.toBase62("10000000"));
+        assertEquals("15ftgG", Numbers.toBase62("1000000000"));
+        assertEquals("1l9Zo9o", Numbers.toBase62("100000000000"));
+        assertEquals("2q3Rktoe", Numbers.toBase62("10000000000000"));
+        assertEquals("4ZxYle1gW", Numbers.toBase62("1000000000000000"));
     }
 
 }

--- a/src/test/resources/io/deephaven/benchmark/run/test-benchmark-results.csv
+++ b/src/test/resources/io/deephaven/benchmark/run/test-benchmark-results.csv
@@ -1,6 +1,9 @@
 run_id,benchmark_name,origin,timestamp,test_duration,op_duration,op_rate,row_count
 1,AvgBy- 2 Groups 160K Unique Combos Int -Static,deephaven-engine,1688376932899,21.3360,12.0680,14915478,180000000
-2,AvgBy- 2 Groups 160K Unique Combos Int -Inc,deephaven-engine,1688376954235,21.2960,12.4870,9609994,120000000
-3,MedianBy- 2 Group 160K Unique Combos Float -Static,deephaven-engine,1688375192283,24.9090,16.6020,2409348,40000000
-4,MedianBy- 2 Group 160K Unique Combos Float -Inc,deephaven-engine,1688375217193,26.0260,17.9630,2226799,40000000
-5,NoOp- 20 Double Cols JSON Append,deephaven-engine,1688374272565,26.0520,11.8600,210792,2500000
+2,AvgBy- 2 Groups 160K Unique Combos Int -Static,deephaven-engine,1688376932899,21.8360,12.5680,13915478,180000000
+3,AvgBy- 2 Groups 160K Unique Combos Int -Inc,deephaven-engine,1688376954235,21.2960,12.4870,9609994,120000000
+4,MedianBy- 2 Group 160K Unique Combos Float -Static,deephaven-engine,1688375192283,24.6090,16.6020,2409348,40000000
+6,MedianBy- 2 Group 160K Unique Combos Float -Static,deephaven-engine,1688375192283,24.8090,16.8020,2209348,40000000
+5,MedianBy- 2 Group 160K Unique Combos Float -Static,deephaven-engine,1688375192283,24.7090,16.7020,2309348,40000000
+7,MedianBy- 2 Group 160K Unique Combos Float -Inc,deephaven-engine,1688375217193,26.0260,17.9630,2226799,40000000
+8,NoOp- 20 Double Cols JSON Append,deephaven-engine,1688374272565,26.0520,11.8600,210792,2500000


### PR DESCRIPTION
- Added user-supplied metrics for queries and made metrics simpler
  - Added `data.file.size` user metric to Parquet tests
  - Reworked queries to allow joining metrics that are not present for every benchmark
- Got rid of collection of before and after bean metrics (They didn't really provide insight)
- Added iterations that run only on benchmark tests that have tag annotations (ex `@Tag("Iterate"`)
- Unified the directory structure for all categories in GCloud (ex. `category/owner/set-label/run-label/`)
  - Updated all workflows and query snippets to this effect
  - Wrote converters for each category; nightly, release, compare
- Added default set labels for each category
  - adhoc blank: `set-23YGkqB`
  - nightly: `2024-07-11` (ex. 
  - release and compare: `00.035.05`
- Default input properties are now specified at the top level workflow level regardless of category
- SVG templates now generated to the 'set' directory and latest to the owner directory
  - Updated generation and README.md links
- Reworked generator file names and added file-name hashes for looking up reusable data
- Updated _benchmark_tables.py_ and _adhoc_tables.py_ in GCloud for use with the other snippets