### PR TITLE
Fixed summary svg generation for duplicate empty platform values

### DIFF
--- a/src/main/java/io/deephaven/benchmark/run/SvgSummary.java
+++ b/src/main/java/io/deephaven/benchmark/run/SvgSummary.java
@@ -120,7 +120,7 @@ class SvgSummary {
         public int compare(Row r1, Row r2) {
             var v1 = r1.getValue(sortKey);
             var v2 = r2.getValue(sortKey);
-            if (!isNumber)
+            if (!isNumber || v1.isBlank() || v2.isBlank())
                 return v1.compareTo(v2);
             var d1 = (Double) Numbers.parseNumber(v1).doubleValue();
             var d2 = (Double) Numbers.parseNumber(v2).doubleValue();
@@ -133,7 +133,7 @@ class SvgSummary {
             Integer index = header.get(colName);
             if (index == null)
                 throw new RuntimeException("Undefined benchmark column name: " + colName);
-            return values[index].trim();
+            return (index < values.length) ? values[index].trim() : "";
         }
 
         String getVarName() {
@@ -143,10 +143,6 @@ class SvgSummary {
                 name += (i == 0) ? v : (">>" + v);
             }
             return name;
-        }
-
-        boolean isNewerThan(Row other) {
-            return (other == null) ? true : (getValue("run-id").compareTo(other.getValue("run-id")) > 0);
         }
     }
 

--- a/src/test/resources/io/deephaven/benchmark/run/test-platform-results.csv
+++ b/src/test/resources/io/deephaven/benchmark/run/test-platform-results.csv
@@ -16,3 +16,6 @@ run_id,origin,name,value
 1,deephaven-engine,available.processors,16
 1,deephaven-engine,java.max.memory,24g
 1,deephaven-engine,deephaven.version,0.28.0
+1,deephaven-engine,deephaven.version,0.28.0
+1,duplicate,myname,
+1,duplicate,myname,myval


### PR DESCRIPTION
- Added test data that reproduces the issue
- Added null/empty check for sorting values