### PR TITLE
Autotune inc on right join table

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -215,6 +215,7 @@ final public class StandardTestRunner {
 
     Result runStaticTest(String name, String operation, String read, String... loadColumns) {
         var staticQuery = """
+        source = right = timed = None
         ${loadSupportTables}
         ${mainTable} = ${readTable}
         loaded_tbl_size = ${mainTable}.size
@@ -242,18 +243,17 @@ final public class StandardTestRunner {
 
     Result runIncTest(String name, String operation, String read, String... loadColumns) {
         var incQuery = """
+        source = right = timed = None
         ${loadSupportTables}
         ${mainTable} = ${readTable}
         loaded_tbl_size = ${mainTable}.size
         ${setupQueries}
         
-        right_on = True
-        
         autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')
         source_filter = autotune(0, 1000000, 1.0, True)
         ${mainTable} = ${mainTable}.where(source_filter)
-        if right and right_on: 
-            right_filter = autotune(0, 100000, 1.0, True)
+        if right: 
+            right_filter = autotune(0, 1010000, 1.0, True)
             right = right.where(right_filter)
             print('Using Inc Right')
         
@@ -264,13 +264,13 @@ final public class StandardTestRunner {
         begin_time = time.perf_counter_ns()
         result = ${operation}
         
-        if right and right_on: right_filter.start()
+        if right: right_filter.start()
         source_filter.start()
         
         from deephaven.execution_context import get_exec_ctx
         get_exec_ctx().update_graph.j_update_graph.requestRefresh()
         
-        if right and right_on: right_filter.waitForCompletion()
+        if right: right_filter.waitForCompletion()
         source_filter.waitForCompletion()
         
         end_time = time.perf_counter_ns()

--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -246,9 +246,16 @@ final public class StandardTestRunner {
         ${mainTable} = ${readTable}
         loaded_tbl_size = ${mainTable}.size
         ${setupQueries}
+        
+        right_on = True
+        
         autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')
         source_filter = autotune(0, 1000000, 1.0, True)
         ${mainTable} = ${mainTable}.where(source_filter)
+        if right and right_on: 
+            right_filter = autotune(0, 100000, 1.0, True)
+            right = right.where(right_filter)
+            print('Using Inc Right')
         
         garbage_collect()
         
@@ -256,11 +263,16 @@ final public class StandardTestRunner {
         print('${logOperationBegin}')
         begin_time = time.perf_counter_ns()
         result = ${operation}
+        
+        if right and right_on: right_filter.start()
         source_filter.start()
         
         from deephaven.execution_context import get_exec_ctx
         get_exec_ctx().update_graph.j_update_graph.requestRefresh()
+        
+        if right and right_on: right_filter.waitForCompletion()
         source_filter.waitForCompletion()
+        
         end_time = time.perf_counter_ns()
         print('${logOperationEnd}')
         standard_metrics = bench_api_metrics_collect()
@@ -337,6 +349,7 @@ final public class StandardTestRunner {
         import numba as nb
         
         bench_api_metrics_init()
+        source = right = timed = None
         """;
 
         this.api = Bench.create(testInst);

--- a/src/main/java/io/deephaven/benchmark/util/Ids.java
+++ b/src/main/java/io/deephaven/benchmark/util/Ids.java
@@ -3,12 +3,14 @@ package io.deephaven.benchmark.util;
 
 import java.time.Instant;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Provide unique Ids for file naming
  */
 public class Ids {
     static final Random random = new Random();
+    static final AtomicInteger delta = new AtomicInteger(new Random().nextInt(100000, 999999));
 
     /**
      * Replace any characters in the given name that may not be safe to use as a file name
@@ -40,14 +42,17 @@ public class Ids {
     }
 
     /**
-     * Return a unique identifier (not a UUID) ex. Fd7YDsw.1.bjSAVA
+     * Make a unique time-based identifier (not a UUID). Successive calls guarantee a unique name returned within a
+     * single JVM.
+     * <p/>
+     * ex. PREFIX.UIuyguJ.2cOP
      * 
      * @return the unique name
      */
     static public String uniqueName(String prefix) {
         String time = nowBase62();
-        String rand = Numbers.toBase62(Math.abs(random.nextInt()));
-        return String.join(".", prefix, time, rand);
+        String d = Numbers.toBase62(Math.abs(delta.incrementAndGet()));
+        return String.join(".", prefix, time, d);
     }
 
     /**

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/adhoc_tables.dh.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/adhoc_tables.dh.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending 
+#
 # Supporting Deephaven queries to use the benchmark_snippet to investigate changes between two or more
 # adhoc benchmark set runs
 # - Make a table containing rates and diffs for the given benchmark sets

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/nightly.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/nightly.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending 
+# Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending 
 #
 # Supporting Deephaven queries to use the benchmark_snippet to investigate changes between nightly benchmarks
 # - Drill into nightly rate gain/loss for a single operations for a date-time range

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/release.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/release.py
@@ -7,7 +7,7 @@
 
 from urllib.request import urlopen; import os
 
-root = 'file:///data' if os.path.exists('/data/deephaven-benchmark') else 'https://storage.googleapis.com'
+root = 'file:///nfs' if os.path.exists('/nfs/deephaven-benchmark') else 'https://storage.googleapis.com'
 with urlopen(root + '/deephaven-benchmark/benchmark_tables.dh.py') as r:
     benchmark_storage_uri_arg = root + '/deephaven-benchmark'
     benchmark_category_arg = 'release'  # release | nightly

--- a/src/main/resources/io/deephaven/benchmark/run/profile/samples/benchmark-inc-template.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/samples/benchmark-inc-template.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending 
+#
+# A template Deephaven query that provides a quicker way to produce self-contained
+# benchmarks that are simliar to the real ones run every night
+# - Helps with the inevitable "How to I test this" questions after poor nightly or
+#   adhoc benchmarks
+# - Users can run/test this on their own Deephaven setups without having to run the 
+#   Benchmark System
+# - It's sometimes easier to test new ideas/fixes this way than doing the full 
+#   benchmark roundtrip first
+
+import time, jpy
+from deephaven import empty_table
+
+row_count = 1_000_000
+
+right = empty_table(1010000).update([
+    'r_key1=``+(ii%100+1)','r_key2=``+(ii%101+1)','r_wild=``+(ii%10000+1)',
+    'r_key4=(int)(ii%99)','r_key5=``+(ii%1010000+1)'
+])
+
+source = empty_table(row_count).update([
+    'num1=(double)randomInt(0,5)','num2=(double)randomInt(1,11)','key1=``+randomInt(1,101)',
+    'key2=``+randomInt(1,102)','key3=randomInt(0,9)','key4=randomInt(0,99)','key5=``+randomInt(1,1_000_001)'
+])
+
+start_time = 1676557157537
+timed = empty_table(row_count).update([
+    'timestamp=start_time+ii','num1=(double)randomInt(0,5)','num2=(double)randomInt(1,11)',
+    'key1=``+randomInt(1,101)','key2=``+randomInt(1,102)','key3=randomInt(0,9)','key4=randomInt(0,99)'
+])
+
+loaded_table_size = source.size
+
+autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')
+source_filter = autotune(0, 1000000, 1.0, True)
+source = source.where(source_filter)
+right_filter = autotune(0, 100000, 1.0, True)
+right = right.where(right_filter)
+
+begin_time = time.perf_counter_ns()
+
+# Add measured operation here
+result = source.natural_join(right, on=['key5 = r_key5'])
+
+right_filter.start()
+source_filter.start()
+
+from deephaven.execution_context import get_exec_ctx
+get_exec_ctx().update_graph.j_update_graph.requestRefresh()
+
+right_filter.waitForCompletion()
+source_filter.waitForCompletion()
+
+end_time = time.perf_counter_ns()
+
+print("Rate(rows/sec):", loaded_table_size / (end_time - begin_time) * 1_000_000_000)
+

--- a/src/main/resources/io/deephaven/benchmark/run/profile/samples/benchmark-static-template.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/samples/benchmark-static-template.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending 
+#
+# A template Deephaven query that provides a quicker way to produce self-contained
+# benchmarks that are simliar to the real ones run every night
+# - Helps with the inevitable "How to I test this" questions after poor nightly or
+#   adhoc benchmarks
+# - Users can run/test this on their own Deephaven setups without having to run the 
+#   Benchmark System
+# - It's sometimes easier to test new ideas/fixes this way than doing the full 
+#   benchmark roundtrip first
+
+import time
+from deephaven import empty_table
+
+row_count = 1_000_000
+
+right = empty_table(1010000).update([
+    'r_key1=``+(ii%100+1)','r_key2=``+(ii%101+1)','r_wild=``+(ii%10000+1)',
+    'r_key4=(int)(ii%99)','r_key5=``+(ii%1010000+1)'
+])
+
+source = empty_table(row_count).update([
+    'num1=(double)randomInt(0,5)','num2=(double)randomInt(1,11)','key1=``+randomInt(1,101)',
+    'key2=``+randomInt(1,102)','key3=randomInt(0,9)','key4=randomInt(0,99)','key5=``+randomInt(1,1_000_001)'
+])
+
+start_time = 1676557157537
+timed = empty_table(row_count).update([
+    'timestamp=start_time+ii','num1=(double)randomInt(0,5)','num2=(double)randomInt(1,11)',
+    'key1=``+randomInt(1,101)','key2=``+randomInt(1,102)','key3=randomInt(0,9)','key4=randomInt(0,99)'
+])
+
+loaded_table_size = source.size
+
+begin_time = time.perf_counter_ns()
+
+# Add measured operation here
+result = source.natural_join(right, on=['key5 = r_key5'])
+
+from deephaven.execution_context import get_exec_ctx
+get_exec_ctx().update_graph.j_update_graph.requestRefresh()
+
+end_time = time.perf_counter_ns()
+
+print("Rate(rows/sec):", loaded_table_size / (end_time - begin_time) * 1_000_000_000)
+

--- a/src/test/java/io/deephaven/benchmark/util/IdsTest.java
+++ b/src/test/java/io/deephaven/benchmark/util/IdsTest.java
@@ -9,7 +9,7 @@ public class IdsTest {
     @Test
     void uniqueName() {
         var ids = new LinkedHashSet<String>();
-        int count = 100000;
+        int count = 1000000;
         for (int i = 0; i < count; i++) {
             ids.add(Ids.uniqueName("p"));
         }


### PR DESCRIPTION
- Right tables for joins now use autotune incremental release as well as left
- Ids.uniqueName now uses delta for second value instead of random, fixing an infrequent failure
- Added static templates for mocking up self-contained queries for troubleshooting benchmarks