### PR TITLE
Tags for worst offenders

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/by/MedianByTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/by/MedianByTest.java
@@ -24,6 +24,7 @@ public class MedianByTest {
     }
 
     @Test
+    @Tag("Iterate")
     void medianBy1Group() {
         runner.setScaleFactors(12, 11);
         var q = "source.median_by(by=['key1'])";

--- a/src/it/java/io/deephaven/benchmark/tests/standard/file/ParquetColTypeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/file/ParquetColTypeTest.java
@@ -41,6 +41,7 @@ class ParquetColTypeTest {
 
     @Test
     @Order(5)
+    @Tag("Iterate")
     void writeOneBigDecimalCol() {
         runner.setScaleFactors(5, 5);
         runner.runParquetWriteTest("ParquetWrite- 1 Big Decimal Col -Static", "NONE", "bigDec10K");
@@ -48,6 +49,7 @@ class ParquetColTypeTest {
 
     @Test
     @Order(6)
+    @Tag("Iterate")
     void readOneBigDecimalCol() {
         runner.setScaleFactors(5, 5);
         runner.runParquetReadTest("ParquetRead- 1 Big Decimal Col -Static");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/file/ParquetMultiColTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/file/ParquetMultiColTest.java
@@ -19,6 +19,7 @@ class ParquetMultiColTest {
 
     @Test
     @Order(1)
+    @Tag("Iterate")
     void writeMultiColSnappy() {
         runner.runParquetWriteTest("ParquetWrite- Snappy Multi Col -Static", "SNAPPY", usedColumns);
     }
@@ -31,6 +32,7 @@ class ParquetMultiColTest {
 
     @Test
     @Order(3)
+    @Tag("Iterate")
     void writeMultiColZstd() {
         runner.runParquetWriteTest("ParquetWrite- Zstd Multi Col -Static", "ZSTD", usedColumns);
     }
@@ -43,6 +45,7 @@ class ParquetMultiColTest {
 
     @Test
     @Order(5)
+    @Tag("Iterate")
     void writeMultiColLzo() {
         runner.runParquetWriteTest("ParquetWrite- Lzo Multi Col -Static", "LZO", usedColumns);
     }

--- a/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/formula/InlineFormulaTest.java
@@ -22,6 +22,7 @@ public class InlineFormulaTest {
     }
 
     @Test
+    @Tag("Iterate")
     void select1Calc1ColFormula() {
         setup(6, 22, 8);
         var q = "source.select(['num2',${calcs}]).sum_by()".replace("${calcs}", calc1col1);
@@ -29,6 +30,7 @@ public class InlineFormulaTest {
     }
 
     @Test
+    @Tag("Iterate")
     void select1Calc2ColsFormula() {
         setup(6, 14, 7);
         var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
@@ -36,6 +38,7 @@ public class InlineFormulaTest {
     }
 
     @Test
+    @Tag("Iterate")
     void select2Calcs2ColsFormula() {
         setup(6, 12, 6);
         var q = "source.select(['num1','num2',${calcs}]).sum_by()".replace("${calcs}", calc2cols2);
@@ -43,6 +46,7 @@ public class InlineFormulaTest {
     }
 
     @Test
+    @Tag("Iterate")
     void update1Calc1ColsFormula() {
         setup(6, 32, 20);
         var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
@@ -50,6 +54,7 @@ public class InlineFormulaTest {
     }
 
     @Test
+    @Tag("Iterate")
     void update1Calc2ColsFormula() {
         setup(6, 22, 16);
         var q = "source.update([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
@@ -86,6 +91,7 @@ public class InlineFormulaTest {
     }
 
     @Test
+    @Tag("Iterate")
     void updateView1Calc1ColFormula() {
         setup(6, 37, 35);
         var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1col1);
@@ -93,6 +99,7 @@ public class InlineFormulaTest {
     }
 
     @Test
+    @Tag("Iterate")
     void updateView1Calc2ColsFormula() {
         setup(6, 22, 20);
         var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc1cols2);
@@ -100,6 +107,7 @@ public class InlineFormulaTest {
     }
 
     @Test
+    @Tag("Iterate")
     void updateView2Calcs2ColsFormula() {
         setup(6, 17, 17);
         var q = "source.update_view([${calcs}]).sum_by()".replace("${calcs}", calc2cols2);

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTickTest.java
@@ -16,6 +16,7 @@ public class EmMaxTickTest {
     final Setup setup = new Setup(runner);
 
     @Test
+    @Tag("Iterate")
     void emMaxTick0Group1Col() {
         setup.factors(5, 14, 12);
         setup.emTick0Groups("emmax_tick");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMaxTimeTest.java
@@ -15,6 +15,7 @@ public class EmMaxTimeTest {
     final Setup setup = new Setup(runner);
 
     @Test
+    @Tag("Iterate")
     void emMaxTime0Group1Col() {
         setup.factors(5, 10, 8);
         setup.emTime0Groups("emmax_time");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTickTest.java
@@ -15,6 +15,7 @@ public class EmMinTickTest {
     final Setup setup = new Setup(runner);
 
     @Test
+    @Tag("Iterate")
     void emMinTick0Group1Col() {
         setup.factors(6, 14, 11);
         setup.emTick0Groups("emmin_tick");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmMinTimeTest.java
@@ -16,6 +16,7 @@ public class EmMinTimeTest {
     final Setup setup = new Setup(runner);
 
     @Test
+    @Tag("Iterate")
     void emMinTime0Group1Col() {
         setup.factors(5, 10, 8);
         setup.emTime0Groups("emmin_time");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmStdTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmStdTickTest.java
@@ -16,6 +16,7 @@ public class EmStdTickTest {
     final Setup setup = new Setup(runner);
 
     @Test
+    @Tag("Iterate")
     void emStdTick0Group1Col() {
         setup.factors(6, 18, 10);
         setup.emTick0Groups("emstd_tick");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmStdTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmStdTimeTest.java
@@ -15,6 +15,7 @@ public class EmStdTimeTest {
     final Setup setup = new Setup(runner);
 
     @Test
+    @Tag("Iterate")
     void emStdTime0Group1Col() {
         setup.factors(5, 12, 10);
         setup.emTime0Groups("emstd_time");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTickTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTickTest.java
@@ -15,6 +15,7 @@ public class EmsTickTest {
     final Setup setup = new Setup(runner);
 
     @Test
+    @Tag("Iterate")
     void emsTick0Group1Col() {
         setup.factors(6, 18, 14);
         setup.emTick0Groups("ems_tick");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTimeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/updateby/EmsTimeTest.java
@@ -15,6 +15,7 @@ public class EmsTimeTest {
     final Setup setup = new Setup(runner);
 
     @Test
+    @Tag("Iterate")
     void emsTime0Group1Col() {
         setup.factors(5, 11, 8);
         setup.emTime0Groups("ems_time");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereInTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereInTest.java
@@ -8,6 +8,7 @@ import io.deephaven.benchmark.tests.standard.StandardTestRunner;
  * Standard tests for the whereIn table operation. Filters rows of data from the source table where the rows match
  * column values in the filter table.
  */
+@Tag("Iterate")
 public class WhereInTest {
     final StandardTestRunner runner = new StandardTestRunner(this);
 
@@ -28,7 +29,6 @@ public class WhereInTest {
     }
 
     @Test
-    @Tag("Iterate")
     void whereIn1Filter() {
         runner.setScaleFactors(135, 100);
         var q = "source.where_in(where_filter, cols=['key1 = set1'])";

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereNotInTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereNotInTest.java
@@ -8,6 +8,7 @@ import io.deephaven.benchmark.tests.standard.StandardTestRunner;
  * Standard tests for the whereNotIn table operation. Filters rows of data from the source table where the rows match
  * column values in the filter table. Note: These benchmarks do the converse of the ones in WhereInTest
  */
+@Tag("Iterate")
 public class WhereNotInTest {
     final StandardTestRunner runner = new StandardTestRunner(this);
 
@@ -28,7 +29,6 @@ public class WhereNotInTest {
     }
 
     @Test
-    @Tag("Iterate")
     void whereNotIn1Filter() {
         runner.setScaleFactors(80, 75);
         var q = "source.where_not_in(where_filter, cols=['key1 = set1'])";

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereOneOfTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereOneOfTest.java
@@ -8,6 +8,7 @@ import io.deephaven.benchmark.tests.standard.StandardTestRunner;
  * Standard tests for the whereOneOf table operation. Filters rows of data from the source table where the rows match
  * column values in the filter table.
  */
+@Tag("Iterate")
 public class WhereOneOfTest {
     final StandardTestRunner runner = new StandardTestRunner(this);
 
@@ -18,7 +19,6 @@ public class WhereOneOfTest {
     }
 
     @Test
-    @Tag("Iterate")
     void whereOneOf1Filter() {
         runner.setScaleFactors(365, 300);
         var q = """

--- a/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/where/WhereTest.java
@@ -7,6 +7,7 @@ import io.deephaven.benchmark.tests.standard.StandardTestRunner;
 /**
  * Standard tests for the where table operation. Filters rows of data from the source table.
  */
+@Tag("Iterate")
 public class WhereTest {
     final StandardTestRunner runner = new StandardTestRunner(this);
 
@@ -17,7 +18,6 @@ public class WhereTest {
     }
 
     @Test
-    @Tag("Iterate")
     void where1Filter() {
         runner.setScaleFactors(330, 310);
         var q = """

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/scores.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/scores.py
@@ -1,0 +1,33 @@
+from deephaven.updateby import rolling_group_tick
+from urllib.request import urlopen; import os
+
+score_threshold = 10.0
+
+root = 'file:///nfs' if os.path.exists('/nfs/deephaven-benchmark') else 'https://storage.googleapis.com'
+with urlopen(root + '/deephaven-benchmark/benchmark_tables.dh.py') as r:
+    benchmark_storage_uri_arg = root + '/deephaven-benchmark'
+    benchmark_max_sets_arg = 100
+    benchmark_category_arg ='nightly'
+    exec(r.read().decode(), globals(), locals())
+
+def count_threshold_hits(scores) -> int:
+    scores = array('d', scores)
+    hits = 0
+    for score in scores:
+        if score <= -score_threshold or score >= score_threshold:
+            hits = hits + 1
+    return hits
+
+op_day5 = rolling_group_tick(cols=['op_rates=op_rate','set_op_rates=set_op_rates'], rev_ticks=6, fwd_ticks=-1)
+scores = bench_results_sets.sort_descending(['benchmark_name','set_id']) \
+    .update_by(ops=[op_day5], by="benchmark_name") \
+    .where(['op_rates.size() > 2']) \
+    .update(['set_op_rates=(long[])merge_arrays(`long`,set_op_rates)','score=zscore(op_rate, op_rates)',
+        'var5d=rstd(op_rates)']) \
+    .group_by(['benchmark_name']) \
+    .update(['op_rate=avg(op_rate)','var5d=avg(var5d)','score_min=min(score)','score_max=max(score)',
+        'score_avg=avg(score)','hits=count_threshold_hits(score)']) \
+    .view(['Benchmark=benchmark_name','Rate=op_rate','Var5d=var5d','ScoreMin=score_min',"ScoreMax=score_max",
+        'ScoreAvg=score_avg','Hits=hits'
+    ])
+


### PR DESCRIPTION
- Added a query to determine occurrences of score outliers over time for the nightly runs.  Since this is based on the previous 5 days average, very bad or good scores are factored into the average, so occurrences are low,
- For the worst offenders, added `@Tag("Iterate")` to get more iterations during the nightly runs
- Where* operations are typically the worst, so the Iterate tag is place at the test class level