### PR TITLE
Dummy workflows

### DIFF
--- a/.github/workflows/adhoc-auto-remote-benchmarks.yml
+++ b/.github/workflows/adhoc-auto-remote-benchmarks.yml
@@ -1,0 +1,19 @@
+
+name: Adhoc Benchmarks (Auto-provisioned Server)
+
+on:
+  workflow_dispatch:
+    inputs:
+      message:
+        message: 'Message'
+        required: true
+        default: ''
+        type: string
+
+jobs:
+  hello-world:
+    runs-on: ubuntu-22.04      
+    steps:
+    - name: Print Message
+      run: echo "Hello ${{ inputs.message }}"
+

--- a/.github/workflows/adhoc-exist-remote-benchmarks.yml
+++ b/.github/workflows/adhoc-exist-remote-benchmarks.yml
@@ -1,0 +1,21 @@
+# Run benchmarks on an already provisioned system
+# - Calls the reusable worflow remote-benchmarks.yml to run and upload benchmarks
+# - Runs the given options with the given image/branch
+
+name: Adhoc Benchmarks (Existing Server)
+
+on:
+  workflow_dispatch:
+    inputs:
+      message:
+        message: 'Message'
+        required: true
+        default: ''
+        type: string
+
+jobs:
+  hello-world:
+    runs-on: ubuntu-22.04      
+    steps:
+    - name: Print Message
+      run: echo "Hello ${{ inputs.message }}"


### PR DESCRIPTION
To manually execute a new workflow_dispatch, the workflow has to exist in "main".  Added some dummy workflows as placeholders for the new adhoc auto-provisioning and adhoc existing server workflows.