### PR TITLE
Added Inc benchmarks to nightly report

### DIFF
--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -40,6 +40,9 @@ on:
       config_options:
         required: true
         type: string
+        
+env:
+  HOST: "${{ inputs.test_device_addr == '<default>' && secrets.BENCHMARK_HOST || inputs.test_device_addr }}"
 
 jobs:
   setup-benchmarks:
@@ -48,7 +51,6 @@ jobs:
       matrix-iterations: ${{ steps.matrix-iterations.outputs.matrix-iterations }}
     env:
       SD: .github/scripts
-      HOST: "${{ inputs.test_device_addr == '<default>' && secrets.BENCHMARK_HOST || inputs.test_device_addr }}"
       USER: ${{secrets.BENCHMARK_USER}}
       REPO: ${{github.repository}}
       BRANCH: ${{github.ref_name}}
@@ -106,7 +108,6 @@ jobs:
         tag: ${{ fromJson(needs.setup-benchmarks.outputs.matrix-iterations) }}
     env: 
       SD: .github/scripts
-      HOST: "${{ inputs.test_device_addr == '<default>' && secrets.BENCHMARK_HOST || inputs.test_device_addr }}"
       USER: ${{secrets.BENCHMARK_USER}}
       RUN_TYPE: ${{inputs.run_type}}
       TEST_PKG: ${{inputs.test_package}}
@@ -131,7 +132,6 @@ jobs:
     runs-on: ubuntu-22.04
     env: 
       SD: .github/scripts
-      HOST: "${{ inputs.test_device_addr == '<default>' && secrets.BENCHMARK_HOST || inputs.test_device_addr }}"
       USER: ${{secrets.BENCHMARK_USER}}
       RUN_TYPE: ${{inputs.run_type}}
       DOCKER_IMG: ${{inputs.docker_image}}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaBlinkHeapTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaBlinkHeapTest.java
@@ -15,7 +15,7 @@ public class KafkaBlinkHeapTest {
 
     @Test
     void CountBy1gHeapFromKafkaAvroBlink() {
-        runner.api.setName("CountBy- 20 Cols 1g Heap Avro Blink");
+        runner.api.setName("CountBy- 20 Cols 1g Heap Avro Blink -Inc");
         runner.restartWithHeap(1);
         runner.table(rowCount / 2, colCount, "long", "avro");
         runner.runTest("consumer_tbl.count_by('count')", "blink");
@@ -23,7 +23,7 @@ public class KafkaBlinkHeapTest {
 
     @Test
     void CountBy1gHeapFromKafkaJsonBlink() {
-        runner.api.setName("CountBy- 20 Cols 1g Heap JSON Blink");
+        runner.api.setName("CountBy- 20 Cols 1g Heap JSON Blink -Inc");
         runner.restartWithHeap(1);
         runner.table(rowCount / 4, colCount, "long", "json");
         runner.runTest("consumer_tbl.count_by('count')", "blink");
@@ -31,7 +31,7 @@ public class KafkaBlinkHeapTest {
 
     @Test
     public void CountBy1gHeapFromKafkaProtobufBlink() {
-        runner.api.setName("CountBy- 20 Cols 1g Heap Protobuf Blink");
+        runner.api.setName("CountBy- 20 Cols 1g Heap Protobuf Blink -Inc");
         runner.restartWithHeap(1);
         runner.table(rowCount / 5, colCount, "long", "protobuf");
         runner.runTest("consumer_tbl.count_by('count')", "blink");
@@ -39,7 +39,7 @@ public class KafkaBlinkHeapTest {
 
     @Test
     void CountBy10gHeapFromKafkaAvroBlink() {
-        runner.api.setName("CountBy- 20 Cols 10g Heap Avro Blink");
+        runner.api.setName("CountBy- 20 Cols 10g Heap Avro Blink -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 2, colCount, "long", "avro");
         runner.runTest("consumer_tbl.count_by('count')", "blink");
@@ -47,7 +47,7 @@ public class KafkaBlinkHeapTest {
 
     @Test
     void CountBy10gHeapFromKafkaJsonBlink() {
-        runner.api.setName("CountBy- 20 Cols 10g Heap JSON Blink");
+        runner.api.setName("CountBy- 20 Cols 10g Heap JSON Blink -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 4, colCount, "long", "json");
         runner.runTest("consumer_tbl.count_by('count')", "blink");
@@ -55,7 +55,7 @@ public class KafkaBlinkHeapTest {
 
     @Test
     public void CountBy10gHeapFromKafkaProtobufBlink() {
-        runner.api.setName("CountBy- 20 Cols 10g Heap Protobuf Blink");
+        runner.api.setName("CountBy- 20 Cols 10g Heap Protobuf Blink -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 5, colCount, "long", "protobuf");
         runner.runTest("consumer_tbl.count_by('count')", "blink");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaBlinkWidthTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaBlinkWidthTest.java
@@ -13,7 +13,7 @@ public class KafkaBlinkWidthTest {
 
     @Test
     void CountBy10ColsFromKafkaAvroBlink() {
-        runner.api.setName("CountBy- 10 Cols Wide Avro Blink");
+        runner.api.setName("CountBy- 10 Cols Wide Avro Blink -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount, 10, "long", "avro");
         runner.runTest("consumer_tbl.count_by('count')", "blink");
@@ -21,7 +21,7 @@ public class KafkaBlinkWidthTest {
 
     @Test
     void CountBy10ColsFromKafkaJsonBlink() {
-        runner.api.setName("CountBy- 10 Cols Wide JSON Blink");
+        runner.api.setName("CountBy- 10 Cols Wide JSON Blink -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount, 10, "long", "json");
         runner.runTest("consumer_tbl.count_by('count')", "blink");
@@ -29,7 +29,7 @@ public class KafkaBlinkWidthTest {
 
     @Test
     void CountBy10ColsFromKafkaProtobufBlink() {
-        runner.api.setName("CountBy- 10 Cols Wide Protobuf Blink");
+        runner.api.setName("CountBy- 10 Cols Wide Protobuf Blink -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 2, 10, "long", "protobuf");
         runner.runTest("consumer_tbl.count_by('count')", "blink");
@@ -37,7 +37,7 @@ public class KafkaBlinkWidthTest {
 
     @Test
     void CountBy100ColsFromKafkaAvroBlink() {
-        runner.api.setName("CountBy- 100 Cols Wide Avro Blink");
+        runner.api.setName("CountBy- 100 Cols Wide Avro Blink -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 3, 100, "long", "avro");
         runner.runTest("consumer_tbl.count_by('count')", "blink");
@@ -45,7 +45,7 @@ public class KafkaBlinkWidthTest {
 
     @Test
     void CountBy100ColsFromKafkaJsonBlink() {
-        runner.api.setName("CountBy- 100 Cols Wide JSON Blink");
+        runner.api.setName("CountBy- 100 Cols Wide JSON Blink -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 10, 100, "long", "json");
         runner.runTest("consumer_tbl.count_by('count')", "blink");
@@ -53,7 +53,7 @@ public class KafkaBlinkWidthTest {
 
     @Test
     void CountBy100ColsFromKafkaProtobufBlink() {
-        runner.api.setName("CountBy- 100 Cols Wide Protobuf Blink");
+        runner.api.setName("CountBy- 100 Cols Wide Protobuf Blink -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 15, 100, "long", "protobuf");
         runner.runTest("consumer_tbl.count_by('count')", "blink");
@@ -61,7 +61,7 @@ public class KafkaBlinkWidthTest {
 
     @Test
     void CountBy1000ColsFromKafkaAvroBlink() {
-        runner.api.setName("CountBy- 1000 Cols Wide Avro Blink");
+        runner.api.setName("CountBy- 1000 Cols Wide Avro Blink -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 25, 1000, "long", "avro");
         runner.runTest("consumer_tbl.count_by('count')", "blink");
@@ -69,7 +69,7 @@ public class KafkaBlinkWidthTest {
 
     @Test
     void CountBy1000ColsgFromKafkaJsonBlink() {
-        runner.api.setName("CountBy- 1000 Cols Wide JSON Blink");
+        runner.api.setName("CountBy- 1000 Cols Wide JSON Blink -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 110, 1000, "long", "json");
         runner.runTest("consumer_tbl.count_by('count')", "blink");
@@ -77,7 +77,7 @@ public class KafkaBlinkWidthTest {
 
     @Test
     void CountBy1000ColsgFromKafkaProtobufBlink() {
-        runner.api.setName("CountBy- 1000 Cols Wide Protobuf Blink");
+        runner.api.setName("CountBy- 1000 Cols Wide Protobuf Blink -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 250, 1000, "long", "protobuf");
         runner.runTest("consumer_tbl.count_by('count')", "blink");

--- a/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaDataTypeTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/kafka/KafkaDataTypeTest.java
@@ -14,7 +14,7 @@ public class KafkaDataTypeTest {
 
     @Test
     void NoOp20LongColsFromKafkaAvroAppend() {
-        runner.api.setName("NoOp- 20 Long Cols Avro Append");
+        runner.api.setName("NoOp- 20 Long Cols Avro Append -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount, colCount, "long", "avro");
         runner.runTest("None", "append");
@@ -22,7 +22,7 @@ public class KafkaDataTypeTest {
 
     @Test
     void NoOp20LongColsFromKafkaJsonAppend() {
-        runner.api.setName("NoOp- 20 Long Cols JSON Append");
+        runner.api.setName("NoOp- 20 Long Cols JSON Append -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 2, colCount, "long", "json");
         runner.runTest("None", "append");
@@ -30,7 +30,7 @@ public class KafkaDataTypeTest {
 
     @Test
     void NoOp20LongColsFromKafkaProtobufAppend() {
-        runner.api.setName("NoOp- 20 Long Cols Protobuf Append");
+        runner.api.setName("NoOp- 20 Long Cols Protobuf Append -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 3, colCount, "long", "protobuf");
         runner.runTest("None", "append");
@@ -38,7 +38,7 @@ public class KafkaDataTypeTest {
 
     @Test
     void NoOp20DoubleColsFromKafkaAvroAppend() {
-        runner.api.setName("NoOp- 20 Double Cols Avro Append");
+        runner.api.setName("NoOp- 20 Double Cols Avro Append -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount, colCount, "double", "avro");
         runner.runTest("None", "append");
@@ -46,7 +46,7 @@ public class KafkaDataTypeTest {
 
     @Test
     void NoOpDoubleColsFromKafkaJsonAppend() {
-        runner.api.setName("NoOp- 20 Double Cols JSON Append");
+        runner.api.setName("NoOp- 20 Double Cols JSON Append -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 4, colCount, "double", "json");
         runner.runTest("None", "append");
@@ -54,7 +54,7 @@ public class KafkaDataTypeTest {
 
     @Test
     void NoOpDoubleColsFromKafkaProtobufAppend() {
-        runner.api.setName("NoOp- 20 Double Cols Protobuf Append");
+        runner.api.setName("NoOp- 20 Double Cols Protobuf Append -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 4, colCount, "double", "protobuf");
         runner.runTest("None", "append");
@@ -62,7 +62,7 @@ public class KafkaDataTypeTest {
 
     @Test
     void NoOp20DateTimeColsFromKafkaAvroAppend() {
-        runner.api.setName("NoOp- 20 DateTime Cols Avro Append");
+        runner.api.setName("NoOp- 20 DateTime Cols Avro Append -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 2, colCount, "timestamp-millis", "avro");
         runner.runTest("None", "append");
@@ -70,7 +70,7 @@ public class KafkaDataTypeTest {
 
     @Test
     void NoOp20DateTimeColsFromKafkaJsonAppend() {
-        runner.api.setName("NoOp- 20 DateTime Cols JSON Append");
+        runner.api.setName("NoOp- 20 DateTime Cols JSON Append -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 2, colCount, "timestamp-millis", "json");
         runner.runTest("None", "append");
@@ -78,7 +78,7 @@ public class KafkaDataTypeTest {
 
     @Test
     void NoOp20DateTimeColsFromKafkaProtobufAppend() {
-        runner.api.setName("NoOp- 20 DateTime Cols Protobuf Append");
+        runner.api.setName("NoOp- 20 DateTime Cols Protobuf Append -Inc");
         runner.restartWithHeap(10);
         runner.table(rowCount / 8, colCount, "timestamp-millis", "protobuf");
         runner.runTest("None", "append");

--- a/src/main/resources/io/deephaven/benchmark/run/profile/benchmark_tables.dh.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/benchmark_tables.dh.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending 
+# Copyright (c) 2023-2024 Deephaven Data Labs and Patent Pending 
 #
 # Deephaven query to run against historical benchmark data stored in GCloud bucket and produce
 # some useful correlated tables

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/adhoc_tables.dh.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/adhoc_tables.dh.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending 
+# Copyright (c) 2023-2024 Deephaven Data Labs and Patent Pending 
 #
 # Supporting Deephaven queries to use the benchmark_snippet to investigate changes between two or more
 # adhoc benchmark set runs

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/compare.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/compare.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending 
+# Copyright (c) 2023-2024 Deephaven Data Labs and Patent Pending 
 #
 # Supporting Deephaven queries to use the benchmark_snippet to investigate product comparisons.
 # - Generate a table that shows the comparisons between products for each benchmark

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/nightly.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/nightly.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending 
+# Copyright (c) 2023-2024 Deephaven Data Labs and Patent Pending 
 #
 # Supporting Deephaven queries to use the benchmark_snippet to investigate changes between nightly benchmarks
 # - Drill into nightly rate gain/loss for a single operations for a date-time range

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/release.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/release.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending 
+# Copyright (c) 2023-2024 Deephaven Data Labs and Patent Pending 
 #
 # Supporting Deephaven queries to use the benchmark_snippet to investigate changes between releases
 # - Generate tables for best and wost static rates between the latest release and previous

--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/scores.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/scores.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2023-2024 Deephaven Data Labs and Patent Pending 
+#
+# Show nightly scores over time. Useful for detecting problematic benchmarks
+# that have periodic outliers
+
 from deephaven.updateby import rolling_group_tick
 from urllib.request import urlopen; import os
 


### PR DESCRIPTION
- Included Inc benchmarks in the nightly publish to slack instead of just the Static ones
- Updated Kafka benchmark names to use `-Inc`
- Moved `HOST` variable to a global environment variable (may do more later to save space)
- Updated some copyrights