### PR TITLE
Workflow concurrency groups

### DIFF
--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -44,8 +44,13 @@ on:
 env:
   HOST: "${{ inputs.test_device_addr == '<default>' && secrets.BENCHMARK_HOST || inputs.test_device_addr }}"
   
+# Workaround for the ommission of support for env vars in concurrency groups
+strategy:
+  matrix:
+    HOST: [${{ env.HOST }}]
+  
 concurrency:
-  group: "${{ inputs.test_device_addr == '<default>' && secrets.BENCHMARK_HOST || inputs.test_device_addr }}"
+  group: "${{ matrix.HOST }}"
   cancel-in-progress: ${{ inputs.run_type == 'nightly' }}
 
 jobs:

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -48,7 +48,7 @@ env:
 strategy:
   matrix:
     HOST: [${{ env.HOST }}]
-  
+
 concurrency:
   group: "${{ matrix.HOST }}"
   cancel-in-progress: ${{ inputs.run_type == 'nightly' }}

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -45,7 +45,7 @@ env:
   HOST: "${{ inputs.test_device_addr == '<default>' && secrets.BENCHMARK_HOST || inputs.test_device_addr }}"
   
 concurrency:
-  group: ${{ env.HOST }}
+  group: "${{ inputs.test_device_addr == '<default>' && secrets.BENCHMARK_HOST || inputs.test_device_addr }}"
   cancel-in-progress: ${{ inputs.run_type == 'nightly' }}
 
 jobs:

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -43,14 +43,9 @@ on:
         
 env:
   HOST: "${{ inputs.test_device_addr == '<default>' && secrets.BENCHMARK_HOST || inputs.test_device_addr }}"
-  
-# Workaround for the ommission of support for env vars in concurrency groups
-strategy:
-  matrix:
-    hostname: "[${{ env.HOST }}]"
 
 concurrency:
-  group: ${{ matrix.hostname }}
+  group: ${{ inputs.test_device_addr }}
   cancel-in-progress: ${{ inputs.run_type == 'nightly' }}
 
 jobs:

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -47,10 +47,10 @@ env:
 # Workaround for the ommission of support for env vars in concurrency groups
 strategy:
   matrix:
-    HOST: ${{ env.HOST }}
+    hostname: "[${{ env.HOST }}]"
 
 concurrency:
-  group: "${{ matrix.HOST }}"
+  group: "${{ matrix.hostname }}"
   cancel-in-progress: ${{ inputs.run_type == 'nightly' }}
 
 jobs:

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -50,7 +50,7 @@ strategy:
     hostname: "[${{ env.HOST }}]"
 
 concurrency:
-  group: "${{ matrix.hostname }}"
+  group: ${{ matrix.hostname }}
   cancel-in-progress: ${{ inputs.run_type == 'nightly' }}
 
 jobs:

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -47,7 +47,7 @@ env:
 # Workaround for the ommission of support for env vars in concurrency groups
 strategy:
   matrix:
-    HOST: [${{ env.HOST }}]
+    HOST: ${{ env.HOST }}
 
 concurrency:
   group: "${{ matrix.HOST }}"

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -43,6 +43,10 @@ on:
         
 env:
   HOST: "${{ inputs.test_device_addr == '<default>' && secrets.BENCHMARK_HOST || inputs.test_device_addr }}"
+  
+concurrency:
+  group: ${{ env.HOST }}
+  cancel-in-progress: ${{ inputs.run_type == 'nightly' }}
 
 jobs:
   setup-benchmarks:


### PR DESCRIPTION
- Added concurrency groups by ip address or default designation
  - This will queue if you try to run multiple runs on your existing BENCHMARK_HOST
- Nightly scheduled runs cancel any existing runs on the Benchmark server