### PR TITLE
fix: Restore Standalone Benchmark Artifact

### DIFF
--- a/.github/scripts/run-benchmarks-remote.sh
+++ b/.github/scripts/run-benchmarks-remote.sh
@@ -41,7 +41,7 @@ cd ${DEEPHAVEN_DIR};
 title "-- Running Benchmarks --"
 cd ${RUN_DIR}
 cat ${RUN_TYPE}-scale-benchmark.properties | sed 's|${baseRowCount}|'"${ROW_COUNT}|g" | sed 's|${baseDistrib}|'"${DISTRIB}|g" > scale-benchmark.properties
-JAVA_OPTS="-Dbenchmark.profile=scale-benchmark.properties -jar deephaven-benchmark-*.jar -cp standard-tests.jar"
+JAVA_OPTS="-Dbenchmark.profile=scale-benchmark.properties -jar deephaven-benchmark-*-standalone.jar -cp standard-tests.jar"
 
 if [ "${TAG_NAME}" = "Any" ]; then
   java ${JAVA_OPTS} -p ${TEST_PACKAGE} -n "${TEST_PATTERN}"

--- a/.github/scripts/run-publish-local.sh
+++ b/.github/scripts/run-publish-local.sh
@@ -37,7 +37,7 @@ sudo docker compose up -d
 sleep 10
 
 cd ${RUN_DIR}
-java -Dbenchmark.profile=${BENCH_PROPS_NAME} -jar deephaven-benchmark-*.jar publish
+java -Dbenchmark.profile=${BENCH_PROPS_NAME} -jar deephaven-benchmark-*-standalone.jar publish
 
 cd ${DEEPHAVEN_DIR};
 sudo docker compose down

--- a/docs/CommandLine.md
+++ b/docs/CommandLine.md
@@ -1,6 +1,6 @@
 # Benchmark - Command Line Usage
 
-Users can run Benchmark in an IDE with a standard JUnit test plugin or from the command line.  The Benchmark artifact (deephaven-benchmark-1.0-SNAPSHOT.jar) 
+Users can run Benchmark in an IDE with a standard JUnit test plugin or from the command line.  The Benchmark standalone jar (deephaven-benchmark-1.0-SNAPSHOT-standalone.jar) 
 contains all dependencies needed to run the framework.  The standalone console launcher for JUnit is used to run the tests, so all of its command line options are 
 available from Benchmark's main jar.
 
@@ -8,17 +8,17 @@ available from Benchmark's main jar.
 
 Have a look at the available arguments:
 ```
-java -jar deephaven-benchmark-1.0-SNAPSHOT.jar --help
+java -jar deephaven-benchmark-1.0-SNAPSHOT-standalone.jar --help
 ```
 
 Run tests in a your own jar
 ```
-java -jar deephaven-benchmark-1.0-SNAPSHOT.jar -cp your-tests.jar -p io.deephaven.your.tests
+java -jar deephaven-benchmark-1.0-SNAPSHOT-standalone.jar -cp your-tests.jar -p io.deephaven.your.tests
 ```
 
 Run tests in your own jar using your own property file
 ```
-java -D"benchmark.profile"="your-benchmark.properties" -jar deephaven-benchmark-1.0-SNAPSHOT.jar -cp your-tests.jar -p your.tests
+java -D"benchmark.profile"="your-benchmark.properties" -jar deephaven-benchmark-1.0-SNAPSHOT-standalone.jar -cp your-tests.jar -p your.tests
 ```
 
 ## Results

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -64,7 +64,8 @@ After checking out the Benchmark project, running *mvn verify* from the director
 the code, package the uber main and test jars, and run some integration tests against your running Deephave Server.
 
 The jar artifacts produce by the build are
-- deephaven-benchmark-1.0-SNAPSHOT.jar: The main uber jar
+- deephaven-benchmark-1.0-SNAPSHOT.jar: The main artifact
+- deephaven-benchmark-1.0-SNAPSHOT-standalone.jar: The standalone super jar
 - deephaven-benchmark-1.0-SNAPSHOT-tests.jar: The jar containing project tests
 
 Run the uber jar according to the [Command Line Guide](CommandLine.md)

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,40 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.5.1</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadedArtifactAttached>true</shadedArtifactAttached>
+							<shadedClassifierName>standalone</shadedClassifierName>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Main-Class>io.deephaven.benchmark.run.BenchmarkMain</Main-Class>
+									</manifestEntries>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.3.0</version>
 				<executions>

--- a/src/main/java/io/deephaven/benchmark/run/BenchmarkMain.java
+++ b/src/main/java/io/deephaven/benchmark/run/BenchmarkMain.java
@@ -10,8 +10,8 @@ import io.deephaven.benchmark.api.Bench;
  * Main class for running the benchmark framework from the deephaven-benchmark artifact. This wraps the JUnit standalone
  * console launcher.
  * <p/>
- * ex. java -Dbenchmark.profile=my-benchmark.properties -jar deephaven-benchmark-1.0-SNAPSHOT.jar -cp my-tests.jar -p
- * my.tests
+ * ex. java -Dbenchmark.profile=my-benchmark.properties -jar deephaven-benchmark-1.0-SNAPSHOT-standalone.jar -cp
+ * my-tests.jar -p my.tests
  * <p/>
  * In addition to running benchmark tests using the console launcher, this class creates a
  * <code>benchmark-summary-results.csv</code> that is a merge of any per-run results files that match

--- a/src/main/resources/io/deephaven/benchmark/run/profile/scripts/smoke-test.sh
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/scripts/smoke-test.sh
@@ -13,7 +13,7 @@ rm -rf /home/stan/Data/benchmark/results
 rm -f /home/stan/Deephaven/deephaven-edge/data/*.def
 rm -f /home/stan/Deephaven/deephaven-edge/data/*.parquet
 
-JAVA_OPTS="-Dbenchmark.profile=scale-benchmark.properties -jar deephaven-benchmark-1.0-SNAPSHOT.jar -cp deephaven-benchmark-1.0-SNAPSHOT-tests.jar"
+JAVA_OPTS="-Dbenchmark.profile=scale-benchmark.properties -jar deephaven-benchmark-1.0-SNAPSHOT-standalone.jar -cp deephaven-benchmark-1.0-SNAPSHOT-tests.jar"
 
 # Run all benchmarks except tagged then run tagged benchmarks with iterations (Similar to what release and nightly do)
 java ${JAVA_OPTS} -p io.deephaven.benchmark.tests.standard -n "^.*[.].*Test.*$"  -T Iterate
@@ -28,7 +28,7 @@ java ${JAVA_OPTS} -p io.deephaven.benchmark.tests.standard -t Iterate
 done
 
 # Publish accumulated results for scores to slack
-java -Dbenchmark.profile=smoke-test-scale-benchmark.properties -jar deephaven-benchmark-1.0-SNAPSHOT.jar publish
+java -Dbenchmark.profile=smoke-test-scale-benchmark.properties -jar deephaven-benchmark-1.0-SNAPSHOT-standalone.jar publish
 
 # Run all benchmarks regardless of tag (Similar to what adhoc and compare do)
 rm -f /home/stan/Deephaven/deephaven-edge/data/*.def


### PR DESCRIPTION
A previous check-in blew away the super jar used for adhoc, night, release and compare testing.  This is not a distributable jar, just used internally.

- Restored the super jar used for testing
- Renamed the jar to use the classifier "-standalone", so that the default artifact name is available for publishing
- Updated the workflows and docs with the new name
- Tested adhoc and compare to exercise the full path