### PR TITLE
fix: Always Use Latest for Release Notes

### DIFF
--- a/.github/scripts/make-release-distro.sh
+++ b/.github/scripts/make-release-distro.sh
@@ -10,32 +10,16 @@ set -o nounset
 # working directory. Also, make a release-notes.md files compared between the given
 # release commit and previous version
 
-if [[ $# != 4 ]]; then
-    echo "$0: Missing release version, release commit, previous version, or distro source argument"
+if [[ $# != 2 ]]; then
+    echo "$0: Missing release version or distro source argument"
     exit 1
 fi
 
 RELEASE_VERSION=$1
-RELEASE_COMMIT=$2
-PREVIOUS_VERSION=$3
-DISTRO_SOURCE=$4
-RELEASE_TAG="v${RELEASE_VERSION}"
-PREVIOUS_TAG="v${PREVIOUS_VERSION}"
+DISTRO_SOURCE=$2
 ARTIFACT=deephaven-benchmark-${RELEASE_VERSION}
 DISTRO_DEST=target/distro
-THIS=$(basename "$0")
-RELEASE_NOTES=target/release-notes.md
 WORKING_DIR=$(pwd)
-
-PREVIOUS_REF=${PREVIOUS_TAG}
-if [[ ${PREVIOUS_VERSION} != *"."*"."* ]]; then
-  PREVIOUS_REF=${PREVIOUS_VERSION}
-fi
-
-# Make the Release Notes File
-echo "**What's Changed**" > ${RELEASE_NOTES}
-git log --oneline ${PREVIOUS_REF}...${RELEASE_COMMIT} | sed -e 's/^/- /' >> ${RELEASE_NOTES}
-echo "**Full Changelog**: https://github.com/deephaven/benchmark/compare/${PREVIOUS_TAG}...${RELEASE_TAG}" >> ${RELEASE_NOTES}
 
 # Generate dependencies directory
 mkdir -p ${DISTRO_DEST}/libs/

--- a/.github/scripts/make-release-notes.sh
+++ b/.github/scripts/make-release-notes.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Copyright (c) 2024-2024 Deephaven Data Labs and Patent Pending
+
+# Generate release notes for the given tags/commits and make a release-notes.md
+# file in the working directory
+
+if [[ $# != 3 ]]; then
+    echo "$0: Missing release version, release commit or previous version argument"
+    exit 1
+fi
+
+RELEASE_VERSION=$1
+RELEASE_COMMIT=$2
+PREVIOUS_VERSION=$3
+RELEASE_TAG="v${RELEASE_VERSION}"
+PREVIOUS_TAG="v${PREVIOUS_VERSION}"
+RELEASE_NOTES=release-notes.md
+
+PREVIOUS_REF=${PREVIOUS_TAG}
+if [[ ${PREVIOUS_VERSION} != *"."*"."* ]]; then
+  PREVIOUS_REF=${PREVIOUS_VERSION}
+fi
+
+# Make the Release Notes File
+echo "**What's Changed**" > ${RELEASE_NOTES}
+git log --oneline ${PREVIOUS_REF}...${RELEASE_COMMIT} | sed -e 's/^/- /' >> ${RELEASE_NOTES}
+echo "**Full Changelog**: https://github.com/deephaven/benchmark/compare/${PREVIOUS_TAG}...${RELEASE_TAG}" >> ${RELEASE_NOTES}
+

--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -61,6 +61,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: release
+        fetch-depth: 0
+        fetch-tags: true
 
     - name: Checkout Distro Target
       working-directory: ${{env.RELEASE_DIR}}

--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -86,7 +86,10 @@ jobs:
       
     - name: Test Release Distro
       working-directory: ${{env.RELEASE_DIR}}
-      run: ${LATEST_DIR}/.github/scripts/test-release-distro.sh ${VERSION}
+      run: |
+        ${LATEST_DIR}/.github/scripts/test-release-distro.sh ${VERSION}
+        mv target/deephaven-benchmark-${VERSION}.tar ${LATEST_DIR}/
+        mv target/deephaven-benchmark-${VERSION}-results.tar ${LATEST_DIR}/
         
     - name: Make Release Notes
       run: .github/scripts/make-release-notes.sh ${VERSION} ${COMMIT} ${PREV_VERSION}
@@ -96,8 +99,8 @@ jobs:
       with:
         name: Deephaven Benchmark Release
         path: |
-          ${{env.RELEASE_DIR}}/target/deephaven-benchmark-${{env.VERSION}}.tar
-          ${{env.RELEASE_DIR}}/target/deephaven-benchmark-${{env.VERSION}}-results.tar
+          deephaven-benchmark-${{env.VERSION}}.tar
+          deephaven-benchmark-${{env.VERSION}}-results.tar
           release-notes.md
           
     - name: Publish Github Release

--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -33,7 +33,7 @@ env:
   VERSION: "${{inputs.version}}"
   COMMIT: "${{inputs.release-commit}}"
   PREV_VERSION: "${{inputs.previous-version}}"
-  LATEST_DIR: ${{github.workspace}}/latest
+  LATEST_DIR: ${{github.workspace}}
   RELEASE_DIR: ${{github.workspace}}/release
 
 permissions:
@@ -54,14 +54,13 @@ jobs:
     - name: Checkout Latest
       uses: actions/checkout@v4
       with:
-        path: latest
+        fetch-depth: 0
+        fetch-tags: true
 
     - name: Checkout Release
       uses: actions/checkout@v4
       with:
         path: release
-        fetch-depth: 0
-        fetch-tags: true
 
     - name: Checkout Distro Target
       working-directory: ${{env.RELEASE_DIR}}
@@ -79,15 +78,16 @@ jobs:
         mvn -B install --file pom.xml
         docker compose down 
       
-    - name: Build Release Distro and Notes
+    - name: Build Release Distribution
       working-directory: ${{env.RELEASE_DIR}}
-      run: ${LATEST_DIR}/.github/scripts/make-release-distro.sh ${VERSION} ${COMMIT} ${PREV_VERSION} ${LATEST_DIR}/.github/distro
+      run: ${LATEST_DIR}/.github/scripts/make-release-distro.sh ${VERSION} ${LATEST_DIR}/.github/distro
       
     - name: Test Release Distro
       working-directory: ${{env.RELEASE_DIR}}
-      run: |
-        ${LATEST_DIR}/.github/scripts/test-release-distro.sh ${VERSION}
-        ls -l ${RELEASE_DIR}/target/
+      run: ${LATEST_DIR}/.github/scripts/test-release-distro.sh ${VERSION}
+        
+    - name: Make Release Notes
+      run: .github/scripts/make-release-notes.sh ${VERSION} ${COMMIT} ${PREV_VERSION}
       
     - name: Archive Results
       uses: actions/upload-artifact@v4
@@ -96,7 +96,7 @@ jobs:
         path: |
           ${{env.RELEASE_DIR}}/target/deephaven-benchmark-${{env.VERSION}}.tar
           ${{env.RELEASE_DIR}}/target/deephaven-benchmark-${{env.VERSION}}-results.tar
-          ${{env.RELEASE_DIR}}/target/release-notes.md
+          release-notes.md
           
     - name: Publish Github Release
       if: ${{ github.ref_name == 'main' }}
@@ -107,6 +107,6 @@ jobs:
         makeLatest: ${{inputs.mark-latest}}
         allowUpdates: true
         artifacts: "${{env.RELEASE_DIR}}/target/deephaven-benchmark-${{env.VERSION}}.tar"
-        bodyFile: "${{env.RELEASE_DIR}}/target/release-notes.md"
+        bodyFile: release-notes.md"
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
 						<configuration>
 							<shadedArtifactAttached>true</shadedArtifactAttached>
 							<shadedClassifierName>standalone</shadedClassifierName>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
 							<filters>
 								<filter>
 									<artifact>*:*</artifact>


### PR DESCRIPTION
- Split up the release distro creation and release notes into two separate steps
- Run the release notes generator from latest
- Fixed an issue where dependencies were missing from the installed POM when both main artifact and super-jar are defined in the same POM file.