### PR TITLE
fix: Update path for release-action asset

### DIFF
--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -111,7 +111,7 @@ jobs:
         commit: ${{env.COMMIT}}
         makeLatest: ${{inputs.mark-latest}}
         allowUpdates: true
-        artifacts: "${{env.RELEASE_DIR}}/target/deephaven-benchmark-${{env.VERSION}}.tar"
+        artifacts: "deephaven-benchmark-${{env.VERSION}}.tar"
         bodyFile: release-notes.md
 
 


### PR DESCRIPTION
A recent change to the path of the tar distro for uploading the artifact broke the path for uploading to the release asset.