### PR TITLE
fix: MetaInf Wrong in Release Artifacts

### DIFF
--- a/.github/scripts/make-release-distro.sh
+++ b/.github/scripts/make-release-distro.sh
@@ -23,7 +23,7 @@ WORKING_DIR=$(pwd)
 # Generate dependencies directory
 mkdir -p ${DISTRO_DEST}/libs/
 cd ${DISTRO_DEST}
-cat ${DISTRO_SOURCE}/dependency-pom.xml | sed -i "s!<version>1.0-SNAPSHOT</version>!<version>${RELEASE_VERSION}</version>!g" > dependency-pom.xml
+cat ${DISTRO_SOURCE}/dependency-pom.xml | sed "s!<version>1.0-SNAPSHOT</version>!<version>${RELEASE_VERSION}</version>!g" > dependency-pom.xml
 mvn -B install --file dependency-pom.xml
 mv target/dependencies/* libs/
 rm -rf target

--- a/.github/scripts/make-release-distro.sh
+++ b/.github/scripts/make-release-distro.sh
@@ -7,8 +7,7 @@ set -o nounset
 # Copyright (c) 2024-2024 Deephaven Data Labs and Patent Pending
 
 # Create a tar file with the given version using the git project located in the 
-# working directory. Also, make a release-notes.md files compared between the given
-# release commit and previous version
+# working directory.
 
 if [[ $# != 2 ]]; then
     echo "$0: Missing release version or distro source argument"
@@ -24,18 +23,18 @@ WORKING_DIR=$(pwd)
 # Generate dependencies directory
 mkdir -p ${DISTRO_DEST}/libs/
 cd ${DISTRO_DEST}
-cp ${DISTRO_SOURCE}/dependency-pom.xml .
+cat ${DISTRO_SOURCE}/dependency-pom.xml | sed -i "s!<version>1.0-SNAPSHOT</version>!<version>${RELEASE_VERSION}</version>!g" > dependency-pom.xml
 mvn -B install --file dependency-pom.xml
 mv target/dependencies/* libs/
 rm -rf target
-rm libs/deephaven-benchmark-*SNAPSHOT*.jar
+rm libs/${ARTIFACT}*.jar
 cd ${WORKING_DIR}
 
 # Build the Distro for running standard benchmarks
 cp ${DISTRO_SOURCE}/* ${DISTRO_DEST}
 rm ${DISTRO_DEST}/dependency-pom.xml
-cp target/deephaven-benchmark-1.0-SNAPSHOT.jar ${DISTRO_DEST}/libs/${ARTIFACT}.jar
-cp target/deephaven-benchmark-1.0-SNAPSHOT-tests.jar ${DISTRO_DEST}/libs/${ARTIFACT}-tests.jar
+cp target/${ARTIFACT}.jar ${DISTRO_DEST}/libs/
+cp target/${ARTIFACT}-tests.jar ${DISTRO_DEST}/libs/
 echo "VERSION=${RELEASE_VERSION}" > ${DISTRO_DEST}/.env
 
 cd ${DISTRO_DEST}

--- a/.github/scripts/make-release-distro.sh
+++ b/.github/scripts/make-release-distro.sh
@@ -15,10 +15,10 @@ if [[ $# != 2 ]]; then
 fi
 
 RELEASE_VERSION=$1
-DISTRO_SOURCE=$2
+DISTRO_SOURCE=$(echo $(cd $(dirname "$2"); pwd)/$(basename "$2"))
 ARTIFACT=deephaven-benchmark-${RELEASE_VERSION}
-DISTRO_DEST=target/distro
 WORKING_DIR=$(pwd)
+DISTRO_DEST=${WORKING_DIR}/target/distro
 
 # Generate dependencies directory
 mkdir -p ${DISTRO_DEST}/libs/

--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Build and Install Release Artifacts Locally
       working-directory: ${{env.RELEASE_DIR}}
       run: | 
-        sed -i "s!<version>1.0-SNAPSHOT</version>!<version>${VERSION}</version>!" pom.xml
+        sed -i "s;<version>1.0-SNAPSHOT</version>;<version>${VERSION}</version>;" pom.xml
         mvn -B install --file pom.xml
         docker compose down
       

--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -77,8 +77,9 @@ jobs:
     - name: Build and Install Release Artifacts Locally
       working-directory: ${{env.RELEASE_DIR}}
       run: | 
+        sed -i "s!<version>1.0-SNAPSHOT</version>!<version>${VERSION}</version>!" pom.xml
         mvn -B install --file pom.xml
-        docker compose down 
+        docker compose down
       
     - name: Build Release Distribution
       working-directory: ${{env.RELEASE_DIR}}


### PR DESCRIPTION
- More testing revealed that the METAINF details (ex. pom xml and properties) were showing 1.0-SNAPSHOT instead of the version
- Fixed and tested in a fork branch