### PR TITLE
feat: Build Sonatype Upload Bundle

### DIFF
--- a/.github/scripts/make-release-artifact-bundle.sh
+++ b/.github/scripts/make-release-artifact-bundle.sh
@@ -24,7 +24,10 @@ ARTIFACT=deephaven-benchmark-${VERSION}
 sed -i "s;<version>1.0-SNAPSHOT</version>;<version>${VERSION}</version>;" pom.xml
 mvn -B install --file pom.xml
 
-cp pom.xml ${ARTIFACT}.pom 
+cp pom.xml ${ARTIFACT}.pom
+cp target/${ARTIFACT}.jar .
+cp target/${ARTIFACT}-sources.jar .
+cp target/${ARTIFACT}-javadoc.jar .
 
 gpg --import ${KEY_FILE}
 gpg -ab ${ARTIFACT}.pom

--- a/.github/scripts/make-release-artifact-bundle.sh
+++ b/.github/scripts/make-release-artifact-bundle.sh
@@ -24,6 +24,8 @@ ARTIFACT=deephaven-benchmark-${VERSION}
 sed -i "s;<version>1.0-SNAPSHOT</version>;<version>${VERSION}</version>;" pom.xml
 mvn -B install --file pom.xml
 
+cp pom.xml ${ARTIFACT}.pom 
+
 gpg --import ${KEY_FILE}
 gpg -ab ${ARTIFACT}.pom
 gpg -ab ${ARTIFACT}.jar

--- a/.github/scripts/make-release-artifact-bundle.sh
+++ b/.github/scripts/make-release-artifact-bundle.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Copyright (c) 2024-2024 Deephaven Data Labs and Patent Pending
+
+# Create a bundle suitable for uploading artifacts to oss.sonatype including pom, sources, javadoc, 
+# artifact and signatures for each. This script expects to run in the directory where the 
+# release branch has been checked out
+#
+# ex. .github/scripts/make-release-bundle.sh 0.33.4 keyfile.asc
+
+if [[ $# != 2 ]]; then
+    echo "$0: Missing release version or signature file argument"
+    exit 1
+fi
+
+VERSION=$1
+KEY_FILE=$2
+ARTIFACT=deephaven-benchmark-${VERSION}
+
+sed -i "s;<version>1.0-SNAPSHOT</version>;<version>${VERSION}</version>;" pom.xml
+mvn -B install --file pom.xml
+
+gpg --import ${KEY_FILE}
+gpg -ab ${ARTIFACT}.pom
+gpg -ab ${ARTIFACT}.jar
+gpg -ab ${ARTIFACT}-javadoc.jar
+gpg -ab ${ARTIFACT}-sources.jar
+
+jar -cvf ../${ARTIFACT}-bundle.jar ${ARTIFACT}.pom ${ARTIFACT}.pom.asc ${ARTIFACT}.jar ${ARTIFACT}.jar.asc ${ARTIFACT}-javadoc.jar ${ARTIFACT}-javadoc.jar.asc ${ARTIFACT}-sources.jar ${ARTIFACT}-sources.jar.asc
+

--- a/.github/scripts/make-release-distro.sh
+++ b/.github/scripts/make-release-distro.sh
@@ -37,8 +37,6 @@ cp ${DISTRO_SOURCE}/* ${DISTRO_DEST}
 rm ${DISTRO_DEST}/dependency-pom.xml
 cp target/${ARTIFACT}.jar ${DISTRO_DEST}/libs/
 cp target/${ARTIFACT}-tests.jar ${DISTRO_DEST}/libs/
-cp target/${ARTIFACT}-sources.jar ${DISTRO_DEST}/libs/
-cp target/${ARTIFACT}-javadoc.jar ${DISTRO_DEST}/libs/
 echo "VERSION=${RELEASE_VERSION}" > ${DISTRO_DEST}/.env
 
 cd ${DISTRO_DEST}

--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -74,12 +74,12 @@ jobs:
         cp ${LATEST_DIR}/.github/resources/integration-docker-compose.yml docker-compose.yml
         docker compose up -d
 
-    - name: Build and Install Release Artifacts Locally
+    - name: Build Release Artifacts Bundle
       working-directory: ${{env.RELEASE_DIR}}
-      run: | 
-        sed -i "s;<version>1.0-SNAPSHOT</version>;<version>${VERSION}</version>;" pom.xml
-        mvn -B install --file pom.xml
-        docker compose down
+      run: |
+          echo ${{secrets.BENCHMARK_SIGNING_KEY}} > signing-key.txt
+          ${LATEST_DIR}/.github/scripts/make-release-artifact-bundle.sh ${VERSION} signing-key.txt
+          docker compose down
       
     - name: Build Release Distribution
       working-directory: ${{env.RELEASE_DIR}}
@@ -102,9 +102,8 @@ jobs:
         path: |
           deephaven-benchmark-${{env.VERSION}}.tar
           deephaven-benchmark-${{env.VERSION}}-results.tar
+          deephaven-benchmark-${{env.VERSION}}-bundle.jar
           release-notes.md
-          deephaven-benchmark-${{env.VERSION}}-sources.jar
-          deephaven-benchmark-${{env.VERSION}}-javadoc.jar
           
     - name: Publish Github Release
       if: ${{ github.ref_name == 'main' }}

--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Build Release Artifacts Bundle
       working-directory: ${{env.RELEASE_DIR}}
       run: |
-          echo ${{secrets.BENCHMARK_SIGNING_KEY}} > signing-key.txt
+          echo "${{secrets.BENCHMARK_SIGNING_KEY}}" > signing-key.txt
           ${LATEST_DIR}/.github/scripts/make-release-artifact-bundle.sh ${VERSION} signing-key.txt
           docker compose down
       

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,31 @@
 	<artifactId>deephaven-benchmark</artifactId>
 	<version>1.0-SNAPSHOT</version>
 	<name>deephaven-benchmark</name>
+	<description>Deephaven Benchmark</description>
+	<url>https://github.com/deephaven/benchmark</url>
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+	<developers>
+		<developer>
+			<id>deephaven</id>
+			<organization>Deephaven Data Labs</organization>
+			<organizationUrl>https://deephaven.io/</organizationUrl>
+			<roles>
+				<role>developer</role>
+			</roles>
+		</developer>
+	</developers>
+	<scm>
+		<connection>scm:git:git@github.com:deephaven/benchmark.git</connection>
+		<developerConnection>scm:git:git@github.com:deephaven/benchmark.git</developerConnection>
+		<url>https://github.com/deephaven/benchmark</url>
+	</scm>
+
 	<build>
 		<testResources>
 			<testResource>
@@ -105,19 +130,19 @@
 				</executions>
 			</plugin>
 			<plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <phase>install</phase>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-        </plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.3.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<phase>install</phase>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
@@ -128,14 +153,14 @@
 					<nohelp>true</nohelp>
 				</configuration>
 				<executions>
-                <execution>
-                    <id>attach-javadocs</id>
-                    <phase>install</phase>
-                    <goals>
-                        <goal>jar</goal>
-                    </goals>
-                </execution>
-            </executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<phase>install</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<!-- For spotless to work on Windows, Set git config global


### PR DESCRIPTION
- Added workflow logic to build an artfact bundle in the Publish workflow
- Added signing to comply with the staging verification step
- Attached the bundle for manual download from the workflow artifacts
- Added license, developer and scm sections to the Benchmark pom 