### PR TITLE
refactor: Better Error Handling for Barrage Connections

### DIFF
--- a/src/main/java/io/deephaven/benchmark/connect/BarrageConnector.java
+++ b/src/main/java/io/deephaven/benchmark/connect/BarrageConnector.java
@@ -52,7 +52,12 @@ public class BarrageConnector implements AutoCloseable {
      * @param hostPort a host and port string for connecting to a Deephaven worker (ex. localhost:10000)
      */
     public BarrageConnector(String hostPort) {
-        String[] split = hostPort.split(":");
+        String[] split;
+        try {
+            split = hostPort.split(":");
+        } catch (Exception ex) {
+            throw new RuntimeException("Failed to parse connection hostPort: " + hostPort, ex);
+        }
         try {
             this.channel = getManagedChannel(split[0], Integer.parseInt(split[1]));
             this.session = getSession(channel);

--- a/src/main/java/io/deephaven/benchmark/connect/BarrageConnector.java
+++ b/src/main/java/io/deephaven/benchmark/connect/BarrageConnector.java
@@ -155,8 +155,11 @@ public class BarrageConnector implements AutoCloseable {
     }
 
     /**
-     * Close the connector session and associated resources. Note: Because of the nature of the Deephaven Community Core
-     * worker, closing the connector session does not close the session on the server.
+     * Make a best effort to close the connector session and all associated resources. No exception is thrown if the
+     * close fails.
+     * <p>
+     * Note: Because of the nature of the Deephaven Community Core worker, closing the connector session does not close
+     * the session on the server.
      */
     public void close() {
         try {
@@ -168,22 +171,27 @@ public class BarrageConnector implements AutoCloseable {
             });
             subscriptions.clear();
             variableNames.clear();
-            if (console != null)
-                console.close();
-            if (session != null)
-                session.close();
         } catch (Exception ex) {
-            throw new RuntimeException("Failed to close Session", ex);
-        } finally {
-            try {
-                if (session != null)
-                    session.session().closeFuture().get(5, TimeUnit.SECONDS);
-                if (scheduler != null)
-                    scheduler.shutdownNow();
-                if (channel != null)
-                    channel.shutdownNow();
-            } catch (Exception ex) {
-            }
+        }
+        try {
+            console.close();
+        } catch (Exception ex) {
+        }
+        try {
+            session.close();
+        } catch (Exception ex) {
+        }
+        try {
+            session.session().closeFuture().get(5, TimeUnit.SECONDS);
+        } catch (Exception ex) {
+        }
+        try {
+            scheduler.shutdownNow();
+        } catch (Exception ex) {
+        }
+        try {
+            channel.shutdownNow();
+        } catch (Exception ex) {
         }
     }
 


### PR DESCRIPTION
- Added more catches of possible error message during the creation of sessions to provide more context
- Use `close()` when errors are found in the constructor in case channel was created before error occurred
- Update `close()` to function better on partially completed session/console creation