### PR TITLE
chore: Upgrade Barrage Java Client 0.36.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.4.0</version>
+				<version>3.6.0</version>
 				<executions>
 					<execution>
 						<id>add-test-source</id>
@@ -76,7 +76,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.11.0</version>
+				<version>3.13.0</version>
 				<configuration>
 					<source>21</source>
 					<target>21</target>
@@ -85,7 +85,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>3.6.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -120,7 +120,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.4.2</version>
 				<executions>
 					<execution>
 						<goals>
@@ -193,7 +193,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.1.2</version>
+				<version>3.5.1</version>
 				<configuration>
 					<excludes>
 						<exclude>/io/deephaven/benchmark/tests/**/*Test</exclude>
@@ -210,7 +210,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.1.2</version>
+				<version>3.5.1</version>
 				<configuration>
 					<forkCount>0</forkCount>
 					<includes>
@@ -247,7 +247,7 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>4.1.96.Final</version>
+			<version>4.1.100.Final</version>
 		</dependency>
 		<!-- Added because of conflicts -->
 		<dependency>
@@ -255,31 +255,31 @@
 			<artifactId>grpc-all</artifactId>
 			<version>1.58.0</version>
 		</dependency>
-		<!-- Added because of conflict with 3.17.3 -->
+		<!-- Added because of conflicts -->
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>3.24.1</version>
+			<version>3.25.3</version>
 		</dependency>
 		<dependency>
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-avro-serializer</artifactId>
-			<version>7.5.3</version>
+			<version>7.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-protobuf-serializer</artifactId>
-			<version>7.5.3</version>
+			<version>7.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.deephaven</groupId>
 			<artifactId>deephaven-java-client-barrage-dagger</artifactId>
-			<version>0.32.0</version>
+			<version>0.36.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.deephaven</groupId>
 			<artifactId>deephaven-log-to-slf4j</artifactId>
-			<version>0.32.0</version>
+			<version>0.36.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>


### PR DESCRIPTION
- Upgraded the Barrage Java Client to 0.36.1
- Upgrade maven plugins to newest versions