### PR TITLE
fix: Warmups Code Revamp

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -215,6 +215,7 @@ final public class StandardTestRunner {
                 'timestamp=timestamp.plusMillis((long)(ii / ${rows}) * ${rows})'
             ])${headRows}.select()
             """;
+            read = read.replace("${headRows}",headRows);
             return read.replace("${scaleFactor}", "" + scaleFactor).replace("${rows}", "" + rowCount);
         }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -206,30 +206,31 @@ final public class StandardTestRunner {
     }
 
     String getReadOperation(int scaleFactor, long rowCount, String... loadColumns) {
+        var headRows = (rowCount >= getGeneratedRowCount())?"":".head(${rows})";
         if (scaleFactor > 1 && mainTable.equals("timed") && Arrays.asList(loadColumns).contains("timestamp")) {
             var read = """
             merge([
                 read('/data/timed.parquet').view(formulas=[${loadColumns}])
             ] * ${scaleFactor}).update_view([
                 'timestamp=timestamp.plusMillis((long)(ii / ${rows}) * ${rows})'
-            ]).head(${rows}).select()
+            ])${headRows}.select()
             """;
             return read.replace("${scaleFactor}", "" + scaleFactor).replace("${rows}", "" + rowCount);
         }
 
-        var read = "read('/data/${mainTable}.parquet').head(${rows}).select(formulas=[${loadColumns}])";
+        var read = "read('/data/${mainTable}.parquet')${headRows}.select(formulas=[${loadColumns}])";
         read = (loadColumns.length == 0) ? ("empty_table(${rows})") : read;
 
         if (scaleFactor > 1) {
             read = "merge([${readTable}] * ${scaleFactor})".replace("${readTable}", read);
             read = read.replace("${scaleFactor}", "" + scaleFactor);
         }
-        return read.replace("${rows}", "" + rowCount);
+        return read.replace("${headRows}",headRows).replace("${rows}", "" + rowCount);
     }
 
-    String getStaticQuery(String name, String operation, long warmupRows, String... loadColumns) {
+    String getStaticQuery(String name, String operation, long rowCount, String... loadColumns) {
         var staticQuery = """
-        source = right = timed = result = None
+        source = right = timed = result = stats = None
         bench_api_metrics_init()
         ${loadSupportTables}
         ${mainTable} = ${readTable}
@@ -253,13 +254,13 @@ final public class StandardTestRunner {
             long_col("result_row_count", [result.size]),
         ])
         """;
-        var read = getReadOperation(staticFactor, warmupRows, loadColumns);
+        var read = getReadOperation(staticFactor, rowCount, loadColumns);
         return populateQuery(name, staticQuery, operation, read, loadColumns);
     }
 
-    String getIncQuery(String name, String operation, long warmupRows, String... loadColumns) {
+    String getIncQuery(String name, String operation, long rowCount, String... loadColumns) {
         var incQuery = """
-        source = right = timed = result = source_filter = right_filter = autotune = None
+        source = right = timed = result = source_filter = right_filter = autotune = stats = None
         bench_api_metrics_init()
         ${loadSupportTables}
         ${mainTable} = ${readTable}
@@ -299,7 +300,7 @@ final public class StandardTestRunner {
             long_col("result_row_count", [result.size])
         ])
         """;
-        var read = getReadOperation(staticFactor, warmupRows, loadColumns);
+        var read = getReadOperation(staticFactor, rowCount, loadColumns);
         return populateQuery(name, incQuery, operation, read, loadColumns);
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -301,7 +301,7 @@ final public class StandardTestRunner {
             long_col("result_row_count", [result.size])
         ])
         """;
-        var read = getReadOperation(staticFactor, rowCount, loadColumns);
+        var read = getReadOperation(incFactor, rowCount, loadColumns);
         return populateQuery(name, incQuery, operation, read, loadColumns);
     }
 

--- a/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/StandardTestRunner.java
@@ -210,10 +210,10 @@ final public class StandardTestRunner {
         if (scaleFactor > 1 && mainTable.equals("timed") && Arrays.asList(loadColumns).contains("timestamp")) {
             var read = """
             merge([
-                read('/data/timed.parquet').view(formulas=[${loadColumns}])
+                read('/data/timed.parquet').view(formulas=[${loadColumns}])${headRows}
             ] * ${scaleFactor}).update_view([
                 'timestamp=timestamp.plusMillis((long)(ii / ${rows}) * ${rows})'
-            ])${headRows}.select()
+            ]).select()
             """;
             read = read.replace("${headRows}",headRows);
             return read.replace("${scaleFactor}", "" + scaleFactor).replace("${rows}", "" + rowCount);

--- a/src/main/resources/io/deephaven/benchmark/run/profile/samples/benchmark-static-template.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/samples/benchmark-static-template.py
@@ -26,7 +26,7 @@ source = empty_table(row_count).update([
 
 start_time = 1676557157537
 timed = empty_table(row_count).update([
-    'timestamp=start_time+ii','num1=(double)randomInt(0,5)','num2=(double)randomInt(1,11)',
+    'timestamp=epochMillisToInstant(start_time+ii)','num1=(double)randomInt(0,5)','num2=(double)randomInt(1,11)',
     'key1=``+randomInt(1,101)','key2=``+randomInt(1,102)','key3=randomInt(0,9)','key4=randomInt(0,99)'
 ])
 


### PR DESCRIPTION
- Warmup code had multiple issues
- Fixed using staticFactor for incFactor
- Moved `head(<rows>)` inside merge for time table benchmarks
- Don't use `head()` unless warmups are active