### PR TITLE
fix: Replaced Redpanda Vectorized Docker URLs

### DIFF
--- a/.github/resources/adhoc-benchmark-docker-compose.yml
+++ b/.github/resources/adhoc-benchmark-docker-compose.yml
@@ -24,7 +24,7 @@ services:
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     - --pandaproxy-addr 0.0.0.0:8082
     - --advertise-pandaproxy-addr redpanda:8082
-    image: docker.redpanda.com/vectorized/redpanda:v23.2.22
+    image: redpandadata/redpanda:v24.1.2
     ports:
     - 8081:8081
     - 8082:8082

--- a/.github/resources/compare-benchmark-docker-compose.yml
+++ b/.github/resources/compare-benchmark-docker-compose.yml
@@ -24,7 +24,7 @@ services:
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     - --pandaproxy-addr 0.0.0.0:8082
     - --advertise-pandaproxy-addr redpanda:8082
-    image: docker.redpanda.com/vectorized/redpanda:v23.2.22
+    image: redpandadata/redpanda:v24.1.2
     ports:
     - 8081:8081
     - 8082:8082

--- a/.github/resources/integration-docker-compose.yml
+++ b/.github/resources/integration-docker-compose.yml
@@ -24,7 +24,7 @@ services:
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     - --pandaproxy-addr 0.0.0.0:8082
     - --advertise-pandaproxy-addr redpanda:8082
-    image: docker.redpanda.com/vectorized/redpanda:v23.2.22
+    image: redpandadata/redpanda:v24.1.2
     ports:
     - 8081:8081
     - 8082:8082

--- a/.github/resources/nightly-benchmark-docker-compose.yml
+++ b/.github/resources/nightly-benchmark-docker-compose.yml
@@ -24,7 +24,7 @@ services:
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     - --pandaproxy-addr 0.0.0.0:8082
     - --advertise-pandaproxy-addr redpanda:8082
-    image: docker.redpanda.com/vectorized/redpanda:v23.2.22
+    image: redpandadata/redpanda:v24.1.2
     ports:
     - 8081:8081
     - 8082:8082

--- a/.github/resources/release-benchmark-docker-compose.yml
+++ b/.github/resources/release-benchmark-docker-compose.yml
@@ -24,7 +24,7 @@ services:
     - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
     - --pandaproxy-addr 0.0.0.0:8082
     - --advertise-pandaproxy-addr redpanda:8082
-    image: docker.redpanda.com/vectorized/redpanda:v23.2.22
+    image: redpandadata/redpanda:v24.1.2
     ports:
     - 8081:8081
     - 8082:8082


### PR DESCRIPTION
Replaced the vectorized docker urls in the docker compose files of all works, since it is deprecated and no longer working.