### PR TITLE
fix: Nightly SVG Footer Shows Variables Not Values

### DIFF
--- a/src/main/java/io/deephaven/benchmark/run/SvgSummary.java
+++ b/src/main/java/io/deephaven/benchmark/run/SvgSummary.java
@@ -64,7 +64,7 @@ class SvgSummary {
             var platformProp = platformProps.get(lookupName);
             var benchmark = benchmarks.get(lookupName);
             if (platformProp != null)
-                return platformProp.getValue(columnName);
+                return formatPlatformValue(lookupName, platformProp.getValue(columnName));
             if (benchmark != null)
                 return Numbers.formatNumber(benchmark.getValue(columnName));
             return "$0";
@@ -103,8 +103,14 @@ class SvgSummary {
     private String replacePlatformVars(String str) {
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         str = str.replace("${run_date}", dtf.format(LocalDateTime.now()));
-        str = str.replace("${os_name}", "Ubuntu 22.04.1 LTS".toLowerCase().replace(" ", "-"));
+        str = str.replace("${os_name}", "Ubuntu 22.04.5 LTS".toLowerCase().replace(" ", "-"));
         return str.replace("${benchmark_count}", "" + benchmarks.size());
+    }
+
+    private String formatPlatformValue(String name, String value) {
+        if (name.contains(".heap"))
+            return Numbers.formatBytesToGigs(value);
+        return value;
     }
 
     class RowComparator implements Comparator<Row> {

--- a/src/main/resources/io/deephaven/benchmark/run/profile/compare-benchmark-summary.template.svg
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/compare-benchmark-summary.template.svg
@@ -123,7 +123,7 @@
       	  <tr><td>Sort</td><td>${Deephaven Sort=>op_rate}</td><td>${PyArrow Sort=>op_rate}</td><td>${Pandas Sort=>op_rate}</td></tr>
       	</tbody>
       	<tfoot>
-		  <tr><td colspan="3">* cpu-threads=${deephaven-engine>>available.processors=>value} heap=${deephaven-engine>>java.max.memory=>value} os=${os_name} full-benchmark-set=${benchmark_count}</td></tr>
+		  <tr><td colspan="3">* cpu-threads=${deephaven-engine>>java.available.processors=>value} heap=${deephaven-engine>>java.max.heap=>value} os=${os_name} full-benchmark-set=${benchmark_count}</td></tr>
 		</tfoot>
       </table>
     </div>

--- a/src/main/resources/io/deephaven/benchmark/run/profile/standard-benchmark-summary.template.svg
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/standard-benchmark-summary.template.svg
@@ -125,7 +125,7 @@
       	  <tr><td>AsOfJoin on 2 Columns Matching 1 Row Each</td><td>${AsOfJoin- Join On 2 Cols -Static=>op_rate}</td><td>${AsOfJoin- Join On 2 Cols -Inc=>op_rate}</td></tr>
       	</tbody>
       	<tfoot>
-		  <tr><td colspan="3">* cpu-threads=${deephaven-engine>>available.processors=>value} heap=${deephaven-engine>>java.max.memory=>value} os=${os_name} full-benchmark-set=${benchmark_count}</td></tr>
+		  <tr><td colspan="3">* cpu-threads=${deephaven-engine>>java.available.processors=>value} heap=${deephaven-engine>>java.max.heap=>value} os=${os_name} full-benchmark-set=${benchmark_count}</td></tr>
 		</tfoot>
       </table>
     </div>

--- a/src/test/java/io/deephaven/benchmark/run/SvgSummaryTest.java
+++ b/src/test/java/io/deephaven/benchmark/run/SvgSummaryTest.java
@@ -39,7 +39,7 @@ public class SvgSummaryTest {
                     <tr><td>Avg By Row1</td><td>14,915,478</td><td>9,609,994</td></tr>
                     <tr><td>Median By Row2</td><td>2,309,348</td><td>2,226,799</td></tr>
                   </tbody>
-                  <tfoot><tr><td colspan="3">* threads=16 heap=24g os=ubuntu-22.04.1-lts benchmark-count=5</td></tr></tfoot>
+                  <tfoot><tr><td colspan="3">* threads=16 heap=24g os=ubuntu-22.04.5-lts benchmark-count=5</td></tr></tfoot>
                 </table>
               </div>
             </foreignObject>


### PR DESCRIPTION
Fixed the issue where the nightly SVG tables were showing variables in the footer instead of the values that should come from platform details.

- Fixed to show the footer values propertly
- Tested for nightly, compare and release SVG generation
- Ran an adhoc workflow to get benchmark-summary.svg, which is the same mechanism as the others.

Jira Ticket: https://deephaven.atlassian.net/browse/DH-18455