### PR TITLE
Allow Connector Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.13.0</version>
 				<configuration>
-					<source>21</source>
-					<target>21</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.10.1</version>
+				<version>3.11.2</version>
 				<configuration>
 					<excludePackageNames>*.connect,*.controller,*.generator,*.jfr,*.metric,*.run,*.util</excludePackageNames>
 					<show>public</show>
@@ -167,7 +167,7 @@
 				'core.autocrlf' to true -->
 				<groupId>com.diffplug.spotless</groupId>
 				<artifactId>spotless-maven-plugin</artifactId>
-				<version>2.43.0</version>
+				<version>2.44.2</version>
 				<configuration>
 					<java>
 						<includes>
@@ -193,7 +193,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>3.5.2</version>
 				<configuration>
 					<excludes>
 						<exclude>/io/deephaven/benchmark/tests/**/*Test</exclude>
@@ -203,14 +203,14 @@
 					<dependency>
 						<groupId>org.junit.jupiter</groupId>
 						<artifactId>junit-jupiter-engine</artifactId>
-						<version>5.9.2</version>
+						<version>5.9.3</version>
 					</dependency>
 				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>3.5.2</version>
 				<configuration>
 					<forkCount>0</forkCount>
 					<includes>
@@ -221,7 +221,7 @@
 					<dependency>
 						<groupId>org.junit.jupiter</groupId>
 						<artifactId>junit-jupiter-engine</artifactId>
-						<version>5.9.2</version>
+						<version>5.9.3</version>
 					</dependency>
 				</dependencies>
 				<executions>
@@ -247,39 +247,39 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>4.1.100.Final</version>
+			<version>4.1.114.Final</version>
 		</dependency>
 		<!-- Added because of conflicts -->
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-all</artifactId>
-			<version>1.58.0</version>
+			<version>1.65.1</version>
 		</dependency>
 		<!-- Added because of conflicts -->
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>3.25.3</version>
+			<version>3.25.4</version>
 		</dependency>
 		<dependency>
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-avro-serializer</artifactId>
-			<version>7.7.1</version>
+			<version>7.9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.confluent</groupId>
 			<artifactId>kafka-protobuf-serializer</artifactId>
-			<version>7.7.1</version>
+			<version>7.9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.deephaven</groupId>
 			<artifactId>deephaven-java-client-barrage-dagger</artifactId>
-			<version>0.36.1</version>
+			<version>0.37.6</version>
 		</dependency>
 		<dependency>
 			<groupId>io.deephaven</groupId>
 			<artifactId>deephaven-log-to-slf4j</artifactId>
-			<version>0.36.1</version>
+			<version>0.37.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.platform</groupId>

--- a/src/main/java/io/deephaven/benchmark/api/BenchQuery.java
+++ b/src/main/java/io/deephaven/benchmark/api/BenchQuery.java
@@ -1,9 +1,10 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2025 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.api;
 
 import java.io.Closeable;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -24,6 +25,7 @@ final public class BenchQuery implements Closeable {
     final QueryLog queryLog;
     final Map<String, Consumer<ResultTable>> snapshotFetchers = new LinkedHashMap<>();
     final Map<String, Function<ResultTable, Boolean>> tickingFetchers = new LinkedHashMap<>();
+    final Properties props = new Properties();
     private Connector session = null;
 
     BenchQuery(Bench bench, String logic, QueryLog queryLog) {
@@ -55,6 +57,16 @@ final public class BenchQuery implements Closeable {
      */
     public BenchQuery fetchDuring(String table, Function<ResultTable, Boolean> tableHandler) {
         tickingFetchers.put(table, tableHandler);
+        return this;
+    }
+
+    /**
+     * Add properties to be passed to the <code>Connector</code> used in the query
+     */
+    public BenchQuery withProperty(String name, String value) {
+        if (value != null && !value.isBlank()) {
+            props.setProperty(name, value);
+        }
         return this;
     }
 
@@ -97,10 +109,10 @@ final public class BenchQuery implements Closeable {
     // Add function defs in separate query so if there are errors in the "logic" part, the line numbers match up
     private void executeBarrageQuery(String logic) {
         if (session == null) {
-            var deephavenServer = bench.property("deephaven.addr", "localhost:10000");
             var connectorClass = bench.property("connector.class", "io.deephaven.benchmark.connect.BarrageConnector");
-            var connectorAuth = bench.property("deephaven.auth", "");
-            session = ConnectorFactory.create(connectorClass, deephavenServer, connectorAuth);
+            var localProps = Bench.profile.getProperties();
+            localProps.putAll(props);
+            session = ConnectorFactory.create(connectorClass, localProps);
         }
         String snippetsLogic = Bench.profile.replaceProperties(Snippets.getFunctions(logic));
         if (!snippetsLogic.isBlank()) {

--- a/src/main/java/io/deephaven/benchmark/api/Profile.java
+++ b/src/main/java/io/deephaven/benchmark/api/Profile.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2024 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2025 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.api;
 
 import java.io.InputStream;
@@ -13,19 +13,20 @@ import io.deephaven.benchmark.run.BenchmarkMain;
 import io.deephaven.benchmark.util.Log;
 
 /**
- * Represents properties for a the Benchmark API .profile file in addition to allowing retrieval of System and
- * environment properties.
+ * Represents properties for the Benchmark API profile file in addition to allowing retrieval of System and environment
+ * properties. The default property file (e.g. default.properties) for the profile can be overridden with
+ * <code>System.setProperty("benchmark.profile.default", "my-properties-path")</code>.
  */
 class Profile {
     final private URL url;
     final private Properties props;
 
     /**
-     * Initialize the profile from the supplied benchmark.profile property. That that property is absent, use the
-     * default properties file.
+     * Initialize the profile from the supplied "benchmark.profile" property. If that property is absent, use the
+     * "benchmark.profile.default" property. If that property is absent, use the "default.properties" resource file.
      */
     Profile() {
-        this(System.getProperty("benchmark.profile", "default.properties"));
+        this(System.getProperty("benchmark.profile", getProfileDefaultFile()));
     }
 
     /**
@@ -216,6 +217,10 @@ class Profile {
         } catch (Exception ex) {
             throw new RuntimeException("Failed to find resource profile: " + uri);
         }
+    }
+
+    static String getProfileDefaultFile() {
+        return System.getProperty("benchmark.profile.default", "default.properties");
     }
 
 }

--- a/src/main/java/io/deephaven/benchmark/connect/BarrageConnector.java
+++ b/src/main/java/io/deephaven/benchmark/connect/BarrageConnector.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023 Deephaven Data Labs and Patent Pending */
+/* Copyright (c) 2022-2025 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.connect;
 
 import java.util.*;
@@ -51,7 +51,9 @@ class BarrageConnector implements Connector {
      * 
      * @param hostPort a host and port string for connecting to a Deephaven worker (ex. localhost:10000)
      */
-    BarrageConnector(String hostPort, String userPass) {
+    BarrageConnector(Properties props) {
+        var hostPort = props.getProperty("deephaven.addr", "localhost:10000");
+        var userPass = props.getProperty("deephaven.auth", "");
         var host = hostPort.replaceAll(":.*", "");
         var port = hostPort.replaceAll(".*:", "");
         if (host.isEmpty() || port.isEmpty())

--- a/src/main/java/io/deephaven/benchmark/connect/Connector.java
+++ b/src/main/java/io/deephaven/benchmark/connect/Connector.java
@@ -1,0 +1,22 @@
+/* Copyright (c) 2022-2025 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.connect;
+
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import io.deephaven.benchmark.metric.Metrics;
+
+public interface Connector extends AutoCloseable {
+
+    public void executeQuery(String query);
+
+    public Set<String> getUsedVariableNames();
+
+    public Future<Metrics> fetchSnapshotData(String table, Consumer<ResultTable> tableHandler);
+
+    public Future<Metrics> fetchTickingData(String table, Function<ResultTable, Boolean> tableHandler);
+
+    public void close();
+
+}

--- a/src/main/java/io/deephaven/benchmark/connect/ConnectorFactory.java
+++ b/src/main/java/io/deephaven/benchmark/connect/ConnectorFactory.java
@@ -1,0 +1,15 @@
+/* Copyright (c) 2022-2025 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.connect;
+
+public class ConnectorFactory {
+    static public Connector create(String connectorClassName, String hostPort, String userPass) {
+        try {
+            var myClass = Class.forName(connectorClassName);
+            var constructor = myClass.getDeclaredConstructor(String.class, String.class);
+            return (Connector) constructor.newInstance(hostPort, userPass);
+        } catch (Exception ex) {
+            throw new RuntimeException("Failed to instantiate Connector: " + hostPort, ex);
+        }
+    }
+
+}

--- a/src/main/java/io/deephaven/benchmark/connect/ConnectorFactory.java
+++ b/src/main/java/io/deephaven/benchmark/connect/ConnectorFactory.java
@@ -1,14 +1,19 @@
 /* Copyright (c) 2022-2025 Deephaven Data Labs and Patent Pending */
 package io.deephaven.benchmark.connect;
 
+import java.util.Properties;
+
+/**
+ * Instantiate the <code>Connector</code> for the given full-qualified class name with the given properties.
+ */
 public class ConnectorFactory {
-    static public Connector create(String connectorClassName, String hostPort, String userPass) {
+    static public Connector create(String connectorClassName, Properties props) {
         try {
             var myClass = Class.forName(connectorClassName);
-            var constructor = myClass.getDeclaredConstructor(String.class, String.class);
-            return (Connector) constructor.newInstance(hostPort, userPass);
+            var constructor = myClass.getDeclaredConstructor(Properties.class);
+            return (Connector) constructor.newInstance(props);
         } catch (Exception ex) {
-            throw new RuntimeException("Failed to instantiate Connector: " + hostPort, ex);
+            throw new RuntimeException("Failed to instantiate Connector: " + connectorClassName, ex);
         }
     }
 

--- a/src/main/java/io/deephaven/benchmark/util/Numbers.java
+++ b/src/main/java/io/deephaven/benchmark/util/Numbers.java
@@ -88,18 +88,21 @@ public class Numbers {
      * @return the negated number or null if <code>val</code> was null
      */
     static public Number negate(Object val) {
-        if (val instanceof Number && ((Number) val).doubleValue() == 0.0)
+        if (val == null || (val instanceof Number && ((Number) val).doubleValue() == 0.0))
             return (Number) val;
-        return switch (val) {
-            case Integer v -> -v.intValue();
-            case Float v -> -v.floatValue();
-            case Long v -> -v.longValue();
-            case Double v -> -v.doubleValue();
-            case Short v -> (short) (-v.shortValue());
-            case Byte v -> (byte) (-v.byteValue());
-            case null -> null;
-            default -> throw new RuntimeException("Unsupported Type: " + val.getClass().getSimpleName());
-        };
+        if (val instanceof Integer)
+            return -((Integer) val).intValue();
+        if (val instanceof Float)
+            return -((Float) val).floatValue();
+        if (val instanceof Long)
+            return -((Long) val).longValue();
+        if (val instanceof Double)
+            return -((Double) val).doubleValue();
+        if (val instanceof Short)
+            return (short) -((Short) val).shortValue();
+        if (val instanceof Byte)
+            return (byte) -((Byte) val).byteValue();
+        throw new RuntimeException("Unsupported Type: " + val.getClass().getSimpleName());
     }
 
     /**
@@ -111,11 +114,11 @@ public class Numbers {
      * @return true if an even number, otherwise false
      */
     static public boolean isEven(Object val) {
-        return switch (val) {
-            case Number v -> v.longValue() % 2 == 0;
-            case null -> false;
-            default -> throw new RuntimeException("Unsupported Type: " + val.getClass().getSimpleName());
-        };
+        if (val == null)
+            return false;
+        if (val instanceof Number)
+            return ((Number) val).longValue() % 2 == 0;
+        throw new RuntimeException("Unsupported Type: " + val.getClass().getSimpleName());
     }
 
     /**

--- a/src/main/resources/io/deephaven/benchmark/run/profile/default.properties
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/default.properties
@@ -1,4 +1,10 @@
 
+# The fully-qualified class name of the connector used in the tests
+connector.class=
+
+# Description of the authentication to use (e.g. user:pass)
+deephaven.auth=
+
 # Deephaven engine address (same one the UI uses)
 deephaven.addr=localhost:10000
 

--- a/src/test/java/io/deephaven/benchmark/util/NumbersTest.java
+++ b/src/test/java/io/deephaven/benchmark/util/NumbersTest.java
@@ -2,7 +2,6 @@
 package io.deephaven.benchmark.util;
 
 import static org.junit.jupiter.api.Assertions.*;
-import java.math.BigInteger;
 import org.junit.jupiter.api.*;
 
 public class NumbersTest {


### PR DESCRIPTION
- Provide a Connector interface to allow plugging in a non-community (e.g. DHE) for Barrage
- Provide property configuration for the Connector a common way
- Upgraded dependency versions including Community barrage client
- Added property for specifying default profile location according to the connector used
- Downgraded from Java 21 to Java 17 because DHE expects JVM 17 and below (This had only a minor affect on the Benchmark code)