### PR TITLE
chore: DH-19145 Change build JDK from 11 to 17

### DIFF
--- a/.github/scripts/build-server-distribution-remote.sh
+++ b/.github/scripts/build-server-distribution-remote.sh
@@ -19,7 +19,7 @@ GIT_DIR=/root/git
 DEEPHAVEN_DIR=/root/deephaven
 DOCKER_IMG=$1
 BRANCH_DELIM=":"
-BUILD_JAVA=temurin-11-jdk-amd64
+BUILD_JAVA=temurin-17-jdk-amd64
 
 if [ ! -d "${DEEPHAVEN_DIR}" ]; then
   echo "$0: Missing one or more Benchmark setup directories"

--- a/.github/scripts/setup-test-server-remote.sh
+++ b/.github/scripts/setup-test-server-remote.sh
@@ -41,7 +41,7 @@ if [[ ${UPDATED} != 0 ]]; then
 fi
 
 title "-- Installing JVMs --"
-apt -y install temurin-11-jdk
+apt -y install temurin-17-jdk
 apt -y install temurin-21-jdk
 
 title "-- Installing Maven --"

--- a/.github/scripts/setup-test-server-remote.sh
+++ b/.github/scripts/setup-test-server-remote.sh
@@ -42,7 +42,6 @@ fi
 
 title "-- Installing JVMs --"
 apt -y install temurin-17-jdk
-apt -y install temurin-21-jdk
 
 title "-- Installing Maven --"
 apt -y install maven

--- a/.github/workflows/mvn-integration-test.yml
+++ b/.github/workflows/mvn-integration-test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 21
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '17'
         distribution: 'temurin'
 
     - name: Docker Pull Deephaven and Redpanda

--- a/.github/workflows/mvn-package.yml
+++ b/.github/workflows/mvn-package.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 21
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -45,10 +45,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - name: Set up JDK 21
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '17'
         distribution: 'temurin'
 
     - name: Checkout Latest

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -65,10 +65,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 21
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '17'
         distribution: 'temurin'
         
     - name: Setup Local Scripts
@@ -145,10 +145,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Set up JDK 21
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '17'
         distribution: 'temurin'
     
     - name: Setup Local Scripts


### PR DESCRIPTION
Recent updates to the Jetty Version in DHC requires that DHC be built with JDK 17.  This does not affect nightly Benchmark runs or any other runs that use the pre-built DHC docker images.  It affects only adhoc runs that require branches to be built on-the-fly.

- Change JAVA_HOME version where appropriate
- Change JDK install to install JDK 17 instead of 11
- Since Benchmark is now built with JDK 17, all workflows now use JDK 17 for all builds and runs