### PR TITLE
fix: DH-20482: Added Type Hint to Benchmark Truncation Function

### DIFF
--- a/src/main/resources/io/deephaven/benchmark/run/profile/queries/publish.py
+++ b/src/main/resources/io/deephaven/benchmark/run/profile/queries/publish.py
@@ -64,7 +64,7 @@ nightly_worst_score_large = nightly_score \
         'Change=Decimal(`0.0%`)','Since_Release=Decimal(`0.0%`)',
         'Score=Decimal(`0.0`)','Score_Prob=Decimal(`0.00%`)'])
 
-def benchname(name):
+def benchname(name) -> str:
     btype = 'S' if name.endswith('-Static') else 'I'
     name = name.replace(' -Static','').replace(' -Inc','')
     name = truncate(name, 50)


### PR DESCRIPTION
- Added type hint to the benchmark truncation function used to create the slack posts to the benchmarking channel
