### PR TITLE
fix: Unwanted Asterisk Expansion

### DIFF
--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -129,7 +129,8 @@ jobs:
     
     - name: Run Remote Benchmarks
       run: |
-        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} run-benchmarks-remote ${RUN_TYPE} "${TEST_PKG}" "'"${TEST_CLS}"'" ${ROW_CNT} ${DISTRIB} ${{ matrix.tag }}
+        set -f
+        ${SD}/run-ssh-local.sh ${HOST} ${USER} ${SD} run-benchmarks-remote ${RUN_TYPE} "${TEST_PKG}" "${TEST_CLS}" ${ROW_CNT} ${DISTRIB} ${{ matrix.tag }}
 
   report-benchmarks:
     needs: run-benchmarks


### PR DESCRIPTION
- After the wildcard check, it looks like a single `*` passed from the workflow still expands
- Added `set -f` in the workflow shell before calling the benchmark run