### PR TITLE
chore: DH-20552: Update publishable artifact bundle

### DIFF
--- a/.github/workflows/publish-benchmarks.yml
+++ b/.github/workflows/publish-benchmarks.yml
@@ -102,7 +102,7 @@ jobs:
         path: |
           deephaven-benchmark-${{env.VERSION}}.tar
           deephaven-benchmark-${{env.VERSION}}-results.tar
-          deephaven-benchmark-${{env.VERSION}}-bundle.jar
+          deephaven-benchmark-${{env.VERSION}}-bundle.zip
           release-notes.md
           
     - name: Publish Github Release


### PR DESCRIPTION
- Updated the artifact builder that make the publishable Benchmark artifact bundle
- Since 0.38.0 was released, Sonatype changed their requirements to a different directory structure and more hashes for each file