### PR TITLE
fix: Barrage RunEndEncoded fix

### DIFF
--- a/.github/resources/adhoc-benchmark-docker-compose.yml
+++ b/.github/resources/adhoc-benchmark-docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./data:/data
       - ./minio:/minio
     environment:
-      - "START_OPTS=-DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler ${CONFIG_OPTS}"
+      - "START_OPTS=-DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler -DBarrageUtil.ree.samplingEnabled=false ${CONFIG_OPTS}"
 
   redpanda:
     command:

--- a/.github/resources/compare-benchmark-docker-compose.yml
+++ b/.github/resources/compare-benchmark-docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - "START_OPTS=-Xmx24g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler"
+      - "START_OPTS=-Xmx24g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler -DBarrageUtil.ree.samplingEnabled=false"
 
   redpanda:
     command:

--- a/.github/resources/integration-docker-compose.yml
+++ b/.github/resources/integration-docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - "START_OPTS=-Xmx4g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler"
+      - "START_OPTS=-Xmx4g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler -DBarrageUtil.ree.samplingEnabled=false"
 
   redpanda:
     command:

--- a/.github/resources/nightly-benchmark-docker-compose.yml
+++ b/.github/resources/nightly-benchmark-docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./data:/data
       - ./minio:/minio
     environment:
-      - "START_OPTS=-Xmx24g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler"
+      - "START_OPTS=-Xmx24g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler -DBarrageUtil.ree.samplingEnabled=false"
 
   redpanda:
     command:

--- a/.github/resources/release-benchmark-docker-compose.yml
+++ b/.github/resources/release-benchmark-docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./data:/data
       - ./minio:/minio
     environment:
-      - "START_OPTS=-Xmx24g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler"
+      - "START_OPTS=-Xmx24g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler -DBarrageUtil.ree.samplingEnabled=false"
 
   redpanda:
     command:


### PR DESCRIPTION
This change `feat: DH-22509: Run End Encoding support for Barrage (#8133)` broke compatibility with released versions of deephaven-java-client-barrage-dagger.  The 41.3 client gets `INVALID_ARGUMENT: No known Barrage ChunkReader for arrow type RunEndEncoded to java.lang.String.`

- Added a quick fix for now to the docker compose files `-DBarrageUtil.ree.samplingEnabled=false`