### PR TITLE
fix: Use Run Encoded Default

### DIFF
--- a/.github/resources/adhoc-benchmark-docker-compose.yml
+++ b/.github/resources/adhoc-benchmark-docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./data:/data
       - ./minio:/minio
     environment:
-      - "START_OPTS=-DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler -DBarrageUtil.ree.samplingEnabled=false ${CONFIG_OPTS}"
+      - "START_OPTS=-DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler ${CONFIG_OPTS}"
 
   redpanda:
     command:

--- a/.github/resources/adhoc-scale-benchmark.properties
+++ b/.github/resources/adhoc-scale-benchmark.properties
@@ -42,7 +42,7 @@ timestamp.test.results=
 docker.compose.file=${userHome}/deephaven/docker-compose.yml
 
 # The url used for posting messages to slack
-slack.token=
+slack.token=${slackToken}
 
 # The channel to post notifications to
-slack.channel=
+slack.channel=${slackChannel}

--- a/.github/resources/adhoc-scale-benchmark.properties
+++ b/.github/resources/adhoc-scale-benchmark.properties
@@ -42,7 +42,7 @@ timestamp.test.results=
 docker.compose.file=${userHome}/deephaven/docker-compose.yml
 
 # The url used for posting messages to slack
-slack.token=${slackToken}
+slack.token=
 
 # The channel to post notifications to
-slack.channel=${slackChannel}
+slack.channel=

--- a/.github/resources/compare-benchmark-docker-compose.yml
+++ b/.github/resources/compare-benchmark-docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - "START_OPTS=-Xmx24g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler -DBarrageUtil.ree.samplingEnabled=false"
+      - "START_OPTS=-Xmx24g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler"
 
   redpanda:
     command:

--- a/.github/resources/integration-docker-compose.yml
+++ b/.github/resources/integration-docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./data:/data
     environment:
-      - "START_OPTS=-Xmx4g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler -DBarrageUtil.ree.samplingEnabled=false"
+      - "START_OPTS=-Xmx4g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler"
 
   redpanda:
     command:

--- a/.github/resources/nightly-benchmark-docker-compose.yml
+++ b/.github/resources/nightly-benchmark-docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./data:/data
       - ./minio:/minio
     environment:
-      - "START_OPTS=-Xmx24g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler -DBarrageUtil.ree.samplingEnabled=false"
+      - "START_OPTS=-Xmx24g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler"
 
   redpanda:
     command:

--- a/.github/resources/release-benchmark-docker-compose.yml
+++ b/.github/resources/release-benchmark-docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./data:/data
       - ./minio:/minio
     environment:
-      - "START_OPTS=-Xmx24g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler -DBarrageUtil.ree.samplingEnabled=false"
+      - "START_OPTS=-Xmx24g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler"
 
   redpanda:
     command:


### PR DESCRIPTION
Larry fixed the Run Encoded issue by making a global run-end enabled flag and disabling it by default. https://github.com/deephaven/deephaven-core/pull/8170

- Removed the previous settings that disabled run-end enabled from the benchmark server side
- The defaults should now work with 41.3