### PR TITLE
fix: DH-22865: Demo NFS Sync Auth

### DIFF
--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -190,9 +190,9 @@ jobs:
       if: ${{ env.RUN_TYPE == 'adhoc' }}
       run: |
         ACCESS_TOKEN=$(gcloud auth print-access-token)
-        gcloud compute ssh --zone "us-central1-a" --project "deephaven-oss" dhc-demo-nfs-client \
+        gcloud compute ssh --quiet --zone "us-central1-a" --project "deephaven-oss" dhc-demo-nfs-client \
           --command="sudo env CLOUDSDK_AUTH_ACCESS_TOKEN=${ACCESS_TOKEN} gcloud storage rsync --delete-unmatched-destination-objects --recursive gs://deephaven-benchmark /nfs/deephaven-benchmark"
-        gcloud compute ssh --zone "us-central1-a" --project "deephaven-oss" dhc-demo-nfs-client \
+        gcloud compute ssh --quiet --zone "us-central1-a" --project "deephaven-oss" dhc-demo-nfs-client \
           --command="sudo find /nfs/deephaven-benchmark -mindepth 1 -type d -empty -delete"
 
     - name: Archive Results

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -187,10 +187,11 @@ jobs:
         ${SD}/run-publish-local.sh ${RUN_TYPE} "${{secrets.BENCHMARK_SLACK_CHANNEL}}" "${{secrets.BENCHMARK_SLACK_TOKEN}}" 
 
     - name: Sync GCloud with Demo NFS
-      if: ${{ env.RUN_TYPE != 'adhoc' }}
+      if: ${{ env.RUN_TYPE == 'adhoc' }}
       run: |
+        ACCESS_TOKEN=$(gcloud auth print-access-token)
         gcloud compute ssh --zone "us-central1-a" --project "deephaven-oss" dhc-demo-nfs-client \
-          --command="sudo gcloud storage rsync --delete-unmatched-destination-objects --recursive gs://deephaven-benchmark /nfs/deephaven-benchmark"
+          --command="sudo env CLOUDSDK_AUTH_ACCESS_TOKEN=${ACCESS_TOKEN} gcloud storage rsync --delete-unmatched-destination-objects --recursive gs://deephaven-benchmark /nfs/deephaven-benchmark"
         gcloud compute ssh --zone "us-central1-a" --project "deephaven-oss" dhc-demo-nfs-client \
           --command="sudo find /nfs/deephaven-benchmark -mindepth 1 -type d -empty -delete"
 

--- a/.github/workflows/remote-benchmarks.yml
+++ b/.github/workflows/remote-benchmarks.yml
@@ -187,7 +187,7 @@ jobs:
         ${SD}/run-publish-local.sh ${RUN_TYPE} "${{secrets.BENCHMARK_SLACK_CHANNEL}}" "${{secrets.BENCHMARK_SLACK_TOKEN}}" 
 
     - name: Sync GCloud with Demo NFS
-      if: ${{ env.RUN_TYPE == 'adhoc' }}
+      if: ${{ env.RUN_TYPE != 'adhoc' }}
       run: |
         ACCESS_TOKEN=$(gcloud auth print-access-token)
         gcloud compute ssh --quiet --zone "us-central1-a" --project "deephaven-oss" dhc-demo-nfs-client \


### PR DESCRIPTION
- Fixed a breaking changed with GCloud auth during the rsync to the Demo NFS server