### PR TITLE
feat: DH-23433: Added barrage client benchmarks

### DIFF
--- a/src/it/java/io/deephaven/benchmark/tests/standard/client/BarrageClientTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/client/BarrageClientTest.java
@@ -1,0 +1,31 @@
+/* Copyright (c) 2026-2026 Deephaven Data Labs and Patent Pending */
+package io.deephaven.benchmark.tests.standard.client;
+
+import org.junit.jupiter.api.*;
+import io.deephaven.benchmark.tests.standard.StandardTestRunner;
+
+/**
+ * Standard tests for the ascending sort table operation. Sorts rows of data from the source table according to the
+ * defined columns
+ */
+public class BarrageClientTest {
+    final StandardTestRunner runner = new StandardTestRunner(this);
+
+    @BeforeEach
+    void setup() {
+        runner.tables("source");
+        var q = """	
+        from deephaven.barrage import barrage_session
+        session = barrage_session("localhost", 10000, auth_type="Anonymous")
+        """;
+        runner.addSetupQuery(q);
+    }
+
+    @Test
+    void snapshot() {
+        runner.setScaleFactors(6, 0);
+        var q = "result = session.snapshot(b's/source')";
+        runner.test("Client- Barrage Snapshot", q, "key1", "num1");
+    }
+
+}

--- a/src/it/java/io/deephaven/benchmark/tests/standard/client/BarrageClientTest.java
+++ b/src/it/java/io/deephaven/benchmark/tests/standard/client/BarrageClientTest.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.*;
 import io.deephaven.benchmark.tests.standard.StandardTestRunner;
 
 /**
- * Standard tests for the ascending sort table operation. Sorts rows of data from the source table according to the
- * defined columns
+ * Standard benchmark for Barrage client snapshot throughput. Snapshots a two-column table from the source server.
  */
 public class BarrageClientTest {
     final StandardTestRunner runner = new StandardTestRunner(this);


### PR DESCRIPTION
Added a barrage client benchmark to standard benchmarks that measures throughput for a two column table (String, double) retrieved via snapshot